### PR TITLE
Add Collector the ability to report issues in the licensing data

### DIFF
--- a/lib/license_scout/collector.rb
+++ b/lib/license_scout/collector.rb
@@ -58,6 +58,33 @@ module LicenseScout
       end
     end
 
+    def issue_report
+      report = []
+      license_report = FFI_Yajl::Parser.parse(File.read(license_manifest_path))
+
+      license_report["dependency_managers"].each do |dependency_manager, dependencies|
+        dependencies.each do |dependency|
+          if dependency["name"].nil? || dependency["name"].empty?
+            report << "There is a dependency with a missing name in '#{dependency_manager}'."
+          end
+
+          if dependency["version"].nil? || dependency["version"].empty?
+            report << "Dependency '#{dependency["name"]}' under '#{dependency_manager}' is missing version information."
+          end
+
+          if dependency["license"].nil? || dependency["license"].empty?
+            report << "Dependency '#{dependency["name"]}' version '#{dependency["version"]}' under '#{dependency_manager}' is missing license information."
+          end
+
+          if dependency["license_files"].empty?
+            report << "Dependency '#{dependency["name"]}' version '#{dependency["version"]}' under '#{dependency_manager}' is missing license files information."
+          end
+        end
+      end
+
+      report.empty? ? nil : report.join("\n")
+    end
+
     private
 
     def reset_license_manifest

--- a/spec/license_scout/collector_spec.rb
+++ b/spec/license_scout/collector_spec.rb
@@ -202,6 +202,11 @@ RSpec.describe(LicenseScout::Collector) do
       expect(content).to eq(expected_machine_readable_licenses_content)
     end
 
+    it "does not report any missing license information" do
+      collector.run
+      expect(collector.issue_report).to be_nil
+    end
+
     context "when a dependency's license cannot be detected" do
 
       before do
@@ -246,6 +251,13 @@ RSpec.describe(LicenseScout::Collector) do
           expect(File).to exist(expected_machine_readable_licenses_file)
           content = FFI_Yajl::Parser.parse(File.read(expected_machine_readable_licenses_file))
           expect(content).to eq(expected_machine_readable_licenses_content)
+        end
+
+        it "reports missing licenses and license files" do
+          collector.run
+          report = collector.issue_report
+          expect(report).to include("Dependency 'example2' version '1.2.3' under 'missing_license_dep_manager' is missing license information.")
+          expect(report).to include("Dependency 'example2' version '1.2.3' under 'missing_license_dep_manager' is missing license files information.")
         end
       end
 


### PR DESCRIPTION
Here is an example report from `chef/chef`:

```
Dependency 'json_pure' version '1.8.3' under 'ruby_bundler' is missing license files information.
Dependency 'aws-sdk-core' version '2.3.19' under 'ruby_bundler' is missing license files information.
Dependency 'aws-sdk-resources' version '2.3.19' under 'ruby_bundler' is missing license files information.
Dependency 'aws-sdk' version '2.3.19' under 'ruby_bundler' is missing license files information.
Dependency 'json' version '1.8.3' under 'ruby_bundler' is missing license files information.
Dependency 'binding_of_caller' version '0.7.2' under 'ruby_bundler' is missing license information.
Dependency 'bundler' version '1.12.5' under 'ruby_bundler' is missing license files information.
Dependency 'bundler-audit' version '0.5.0' under 'ruby_bundler' is missing license files information.
Dependency 'fuzzyurl' version '0.8.0' under 'ruby_bundler' is missing license files information.
Dependency 'mixlib-shellout' version '2.2.6' under 'ruby_bundler' is missing license information.
Dependency 'mixlib-log' version '1.6.0' under 'ruby_bundler' is missing license information.
Dependency 'rack' version '1.6.4' under 'ruby_bundler' is missing license files information.
Dependency 'uuidtools' version '2.1.5' under 'ruby_bundler' is missing license information.
Dependency 'erubis' version '2.7.0' under 'ruby_bundler' is missing license information.
Dependency 'plist' version '3.2.0' under 'ruby_bundler' is missing license information.
Dependency 'proxifier' version '1.0.3' under 'ruby_bundler' is missing license information.
Dependency 'net-telnet' version '0.1.1' under 'ruby_bundler' is missing license information.
Dependency 'sfl' version '2.2' under 'ruby_bundler' is missing license information.
Dependency 'sfl' version '2.2' under 'ruby_bundler' is missing license files information.
Dependency 'syslog-logger' version '1.6.8' under 'ruby_bundler' is missing license information.
Dependency 'syslog-logger' version '1.6.8' under 'ruby_bundler' is missing license files information.
Dependency 'mime-types-data' version '3.2016.0521' under 'ruby_bundler' is missing license files information.
Dependency 'cheffish' version '2.0.4' under 'ruby_bundler' is missing license information.
Dependency 'inifile' version '3.0.0' under 'ruby_bundler' is missing license information.
Dependency 'inifile' version '3.0.0' under 'ruby_bundler' is missing license files information.
Dependency 'gssapi' version '1.2.0' under 'ruby_bundler' is missing license files information.
Dependency 'httpclient' version '2.8.0' under 'ruby_bundler' is missing license files information.
Dependency 'little-plugger' version '1.1.4' under 'ruby_bundler' is missing license information.
Dependency 'little-plugger' version '1.1.4' under 'ruby_bundler' is missing license files information.
Dependency 'logging' version '2.1.0' under 'ruby_bundler' is missing license information.
Dependency 'logging' version '2.1.0' under 'ruby_bundler' is missing license files information.
Dependency 'chef-provisioning' version '1.8.0' under 'ruby_bundler' is missing license information.
Dependency 'ubuntu_ami' version '0.4.1' under 'ruby_bundler' is missing license information.
Dependency 'chef-provisioning-aws' version '1.10.0' under 'ruby_bundler' is missing license information.
Dependency 'chef-rewind' version '0.0.9' under 'ruby_bundler' is missing license information.
Dependency 'coderay' version '1.1.1' under 'ruby_bundler' is missing license files information.
Dependency 'multipart-post' version '2.0.0' under 'ruby_bundler' is missing license files information.
Dependency 'polyglot' version '0.3.5' under 'ruby_bundler' is missing license files information.
Dependency 'jwt' version '1.5.1' under 'ruby_bundler' is missing license files information.
Dependency 'method_source' version '0.8.2' under 'ruby_bundler' is missing license information.
Dependency 'pry-remote' version '0.1.8' under 'ruby_bundler' is missing license information.
Dependency 'pry-stack_explorer' version '0.4.9.2' under 'ruby_bundler' is missing license information.
```

/cc: @danielsdeleo @ryancragun 