### PR TITLE
Add ability to fetch license files from internet with a basic local cache and retries

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -32,6 +32,14 @@ overrides = LicenseScout::Overrides.new do
     ["chef-rewind", "MIT", nil],
     ["ubuntu_ami", "Apache-2.0", nil],
     ["net-telnet", "Ruby", nil],
+    # Internet overrides
+    ["sfl", "Ruby", ["https://raw.githubusercontent.com/ujihisa/spawn-for-legacy/master/LICENCE.md"]],
+    ["json_pure", nil, ["https://raw.githubusercontent.com/flori/json/master/README.md"]],
+    ["aws-sdk-core", nil, ["https://raw.githubusercontent.com/aws/aws-sdk-ruby/master/README.md"]],
+    ["aws-sdk-resources", nil, ["https://raw.githubusercontent.com/aws/aws-sdk-ruby/master/README.md"]],
+    ["aws-sdk", nil, ["https://raw.githubusercontent.com/aws/aws-sdk-ruby/master/README.md"]],
+    ["fuzzyurl", nil, ["https://raw.githubusercontent.com/gamache/fuzzyurl/master/LICENSE.txt"]],
+    ["jwt", nil, ["https://github.com/jwt/ruby-jwt/blob/master/LICENSE"]],
   ].each do |override_data|
     override_license "ruby_bundler", override_data[0] do |version|
       {}.tap do |d|
@@ -40,14 +48,6 @@ overrides = LicenseScout::Overrides.new do
       end
     end
   end
-
-  # sfl, https://github.com/ujihisa/spawn-for-legacy/blob/master/LICENCE.md
-  # json_pure, https://github.com/flori/json/blob/master/README.md
-  # aws-sdk-core, aws-sdk-resources, aws-sdk
-  #   https://github.com/aws/aws-sdk-ruby/blob/master/README.md
-  #   http://www.apache.org/licenses/LICENSE-2.0.html
-  # fuzzyurl, https://github.com/gamache/fuzzyurl/blob/master/LICENSE.txt
-  # jwt, https://github.com/jwt/ruby-jwt/blob/master/LICENSE
 end
 
 collector = LicenseScout::Collector.new("chef", chef_directory, output_directory, overrides)

--- a/lib/license_scout/exceptions.rb
+++ b/lib/license_scout/exceptions.rb
@@ -53,5 +53,18 @@ module LicenseScout
     class InaccessibleDependency < Error; end
     class InvalidOverride < Error; end
 
+    class NetworkError < Error
+      def initialize(from_url, network_error)
+        @from_url = from_url
+        @network_error = network_error
+      end
+
+      def to_s
+        [
+          "Network error while fetching '#{from_url}'",
+          network_error.to_s,
+        ].join("\n")
+      end
+    end
   end
 end

--- a/lib/license_scout/net_fetcher.rb
+++ b/lib/license_scout/net_fetcher.rb
@@ -1,0 +1,94 @@
+#
+# Copyright:: Copyright 2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "open-uri"
+require "tmpdir"
+require "digest"
+
+require "license_scout/exceptions"
+
+module LicenseScout
+  class NetFetcher
+
+    attr_reader :from_url
+
+    def initialize(from_url)
+      @from_url = from_url
+    end
+
+    def fetch!
+      download_file! unless exists_in_cache?
+    end
+
+    def cache_dir
+      File.join(Dir.tmpdir, "license_scout_cache")
+    end
+
+    def cache_path
+      File.join(cache_dir, url_cache_key, File.basename(from_url))
+    end
+
+    private
+
+    def exists_in_cache?
+      File.exist?(cache_path)
+    end
+
+    def url_cache_key
+      d = Digest::SHA256.new
+      d.update(from_url)
+      d.hexdigest
+    end
+
+    def save_to_cache(file)
+      cache_directory = File.dirname(cache_path)
+      FileUtils.mkdir_p(cache_directory) unless File.exist?(cache_directory)
+
+      File.open(cache_path, "w+") do |output_file|
+        output_file.print(file.read)
+      end
+    end
+
+    # This method is highly inspired from:
+    # https://github.com/chef/omnibus/blob/master/lib/omnibus/download_helpers.rb
+    def download_file!
+      retries = 3
+
+      begin
+        options = {
+          :read_timeout => 60,
+        }
+
+        open(from_url, options) do |f|
+          save_to_cache(f)
+        end
+      rescue SocketError,
+             Errno::ECONNREFUSED,
+             Errno::ECONNRESET,
+             Errno::ENETUNREACH,
+             Timeout::Error,
+             OpenURI::HTTPError => e
+        if retries != 0
+          retries -= 1
+          retry
+        else
+          raise Exceptions::NetworkError.new(from_url, e)
+        end
+      end
+    end
+  end
+end

--- a/spec/license_scout/net_fetcher_spec.rb
+++ b/spec/license_scout/net_fetcher_spec.rb
@@ -1,0 +1,113 @@
+#
+# Copyright:: Copyright 2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "tmpdir"
+require "fileutils"
+
+require "license_scout/net_fetcher"
+
+RSpec.describe(LicenseScout::NetFetcher) do
+
+  let(:tmpdir) { Dir.mktmpdir }
+
+  before do
+    FileUtils.rm_rf(fetcher.cache_dir)
+  end
+
+  after do
+    FileUtils.rm_rf(tmpdir)
+  end
+
+  subject(:fetcher) { described_class.new(url) }
+
+  let(:url) { "https://chef-license-spec.s3.amazonaws.com/README" }
+  let(:expected_download_content) {
+    <<-EOS
+This folder and file is being used for testing by the following project:
+
+https://github.com/chef/license_scout
+
+Please do not delete!
+EOS
+  }
+
+  let(:expected_cache_path) { fetcher.cache_path }
+
+  it "has a cache directory and cache path" do
+    expect(fetcher.cache_dir).to be_a(String)
+    expect(fetcher.cache_path).to end_with(File.basename(url))
+  end
+
+  describe "when the file on the internet is accessible" do
+
+    it "puts the file in the cache" do
+      fetcher.fetch!
+      expect(File).to exist(expected_cache_path)
+      expect(File.read(expected_cache_path)).to eq(expected_download_content)
+    end
+
+    context "when the cache already contains the file" do
+
+      before do
+        FileUtils.mkdir_p(File.dirname(fetcher.cache_path))
+        FileUtils.touch(fetcher.cache_path)
+      end
+
+      it "picks the cache from the file" do
+        expect(fetcher).not_to receive(:open)
+        fetcher.fetch!
+      end
+    end
+
+  end
+
+  describe "when the file on the internet is not accessible" do
+
+    let(:success_after_count) { 5 }
+
+    before do
+      @call_count = 0
+      original_open = fetcher.method(:open)
+
+      allow(fetcher).to receive(:open) do |url, options, &block|
+        if @call_count == success_after_count
+          original_open.call(url, options, &block)
+        else
+          @call_count += 1
+          raise Errno::ENETUNREACH.new
+        end
+      end
+    end
+
+    it "raises an error after 3 retries" do
+      expect { fetcher.fetch! }.to raise_error(LicenseScout::Exceptions::NetworkError)
+      # open will be called 4 times in total, first call + 3 retries
+      expect(@call_count).to eq(4)
+    end
+
+    context "when the error is temporary" do
+      let(:success_after_count) { 2 }
+
+      it "fetches the file" do
+        fetcher.fetch!
+        expect(File).to exist(expected_cache_path)
+        expect(File.read(expected_cache_path)).to eq(expected_download_content)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Also including the full set of overrides for `chef/chef`

/cc: @danielsdeleo @ryancragun 