### PR TITLE
This commit includes minor changes to enable omnibus integration:

### DIFF
--- a/demo.rb
+++ b/demo.rb
@@ -52,4 +52,4 @@ end
 
 collector = LicenseScout::Collector.new("chef", chef_directory, output_directory, overrides)
 collector.run
-puts collector.issue_report
+puts collector.issue_report.join("\n")

--- a/lib/license_scout/collector.rb
+++ b/lib/license_scout/collector.rb
@@ -28,12 +28,14 @@ module LicenseScout
     attr_reader :output_dir
     attr_reader :license_manifest_data
     attr_reader :overrides
+    attr_reader :environment
 
-    def initialize(project_name, project_dir, output_dir, overrides)
+    def initialize(project_name, project_dir, output_dir, overrides, environment)
       @project_name = project_name
       @project_dir = project_dir
       @output_dir = output_dir
       @overrides = overrides
+      @environment = environment
     end
 
     def dependency_managers
@@ -82,7 +84,7 @@ module LicenseScout
         end
       end
 
-      report.empty? ? nil : report.join("\n")
+      report
     end
 
     private
@@ -130,7 +132,7 @@ module LicenseScout
 
     def all_dependency_managers
       LicenseScout::DependencyManager.implementations.map do |implementation|
-        implementation.new(project_dir, overrides)
+        implementation.new(project_dir, overrides, environment)
       end
     end
   end

--- a/lib/license_scout/dependency_manager/base.rb
+++ b/lib/license_scout/dependency_manager/base.rb
@@ -23,10 +23,12 @@ module LicenseScout
 
       attr_reader :project_dir
       attr_reader :overrides
+      attr_reader :environment
 
-      def initialize(project_dir, overrides)
+      def initialize(project_dir, overrides, environment)
         @project_dir = project_dir
         @overrides = overrides
+        @environment = environment
       end
 
     end

--- a/lib/license_scout/dependency_manager/bundler.rb
+++ b/lib/license_scout/dependency_manager/bundler.rb
@@ -66,8 +66,8 @@ module LicenseScout
 
         Dir.chdir(project_dir) do
 
-          json_dep_data = ::Bundler.with_clean_env do
-            s = Mixlib::ShellOut.new("ruby #{bundler_script}")
+          json_dep_data = with_clean_env do
+            s = Mixlib::ShellOut.new("ruby #{bundler_script}", environment: environment)
             s.run_command
             s.error!
             s.stdout
@@ -120,6 +120,42 @@ module LicenseScout
       end
 
       private
+
+      #
+      # Execute the given command, removing any Ruby-specific environment
+      # variables. This is an "enhanced" version of +Bundler.with_clean_env+,
+      # which only removes Bundler-specific values. We need to remove all
+      # values, specifically:
+      #
+      # - _ORIGINAL_GEM_PATH
+      # - GEM_PATH
+      # - GEM_HOME
+      # - GEM_ROOT
+      # - BUNDLE_BIN_PATH
+      # - BUNDLE_GEMFILE
+      # - RUBYLIB
+      # - RUBYOPT
+      # - RUBY_ENGINE
+      # - RUBY_ROOT
+      # - RUBY_VERSION
+      #
+      # The original environment restored at the end of this call.
+      #
+      # @param [Proc] block
+      #   the block to execute with the cleaned environment
+      #
+      def with_clean_env(&block)
+        original = ENV.to_hash
+
+        ENV.delete("_ORIGINAL_GEM_PATH")
+        ENV.delete_if { |k, _| k.start_with?("BUNDLE_") }
+        ENV.delete_if { |k, _| k.start_with?("GEM_") }
+        ENV.delete_if { |k, _| k.start_with?("RUBY") }
+
+        yield
+      ensure
+        ENV.replace(original.to_hash)
+      end
 
       def auto_detect_license_files(gem_path)
         unless File.exist?(gem_path)

--- a/spec/license_scout/collector_spec.rb
+++ b/spec/license_scout/collector_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe(LicenseScout::Collector) do
   let(:project_name) { "example-project" }
   let(:overrides) { LicenseScout::Overrides.new }
 
-  subject(:collector) { described_class.new(project_name, project_dir, output_dir, overrides) }
+  subject(:collector) { described_class.new(project_name, project_dir, output_dir, overrides, {}) }
 
   after do
     FileUtils.rm_rf(tmpdir)
@@ -204,7 +204,7 @@ RSpec.describe(LicenseScout::Collector) do
 
     it "does not report any missing license information" do
       collector.run
-      expect(collector.issue_report).to be_nil
+      expect(collector.issue_report).to be_empty
     end
 
     context "when a dependency's license cannot be detected" do

--- a/spec/license_scout/dependency_manager/bundler_spec.rb
+++ b/spec/license_scout/dependency_manager/bundler_spec.rb
@@ -21,7 +21,7 @@ require "fileutils"
 require "license_scout/dependency_manager/bundler"
 
 RSpec.describe(LicenseScout::DependencyManager::Bundler) do
-  subject(:bundler) { described_class.new(project_dir, overrides) }
+  subject(:bundler) { described_class.new(project_dir, overrides, {}) }
 
   let(:tmpdir) { Dir.mktmpdir }
 


### PR DESCRIPTION
* Add the ability to pass in an environment to the Collector to be used during license detection.
* Improve with_clean_env method to clean rubygems and ruby environment variables in addition to bundler.
* Always return an array from issue_report.

Also see https://github.com/chef/omnibus/pull/703 for more details. 

/cc: @danielsdeleo @ryancragun 