### PR TITLE
add executable that's usable for demos

### DIFF
--- a/bin/license_scout
+++ b/bin/license_scout
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env ruby
 #
 # Copyright:: Copyright 2016, Chef Software Inc.
 # License:: Apache License, Version 2.0
@@ -15,3 +15,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+$:.unshift File.expand_path("../../lib", __FILE__)
+
+require "license_scout/collector"
+require "license_scout/overrides"
+require "license_scout/options"
+
+project_dir = File.expand_path(Dir.pwd)
+project_name = File.basename(project_dir)
+
+output_dir = project_dir
+
+overrides = LicenseScout::Overrides.new
+
+opts = LicenseScout::Options.new(overrides: overrides)
+
+collector = LicenseScout::Collector.new(project_name, project_dir, output_dir, opts)
+
+collector.run
+report = collector.issue_report
+
+puts report


### PR DESCRIPTION
"real" license scout usage should happen via omnibus, but this is usable to scan an existing project and see what license scout finds.