### PR TITLE
Looks like json gem packaged in Ruby 2.3 does not set the its license in its gemspec.

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -119,6 +119,7 @@ module LicenseScout
         ["net-telnet", "Ruby", nil],
         # Overrides that require file fetching from internet
         ["sfl", "Ruby", ["https://raw.githubusercontent.com/ujihisa/spawn-for-legacy/master/LICENCE.md"]],
+        ["json", "Ruby", nil],
         ["json_pure", nil, ["https://raw.githubusercontent.com/flori/json/master/README.md"]],
         ["aws-sdk-core", nil, ["https://raw.githubusercontent.com/aws/aws-sdk-ruby/master/README.md"]],
         ["aws-sdk-resources", nil, ["https://raw.githubusercontent.com/aws/aws-sdk-ruby/master/README.md"]],


### PR DESCRIPTION
/cc: @danielsdeleo 