### PR TITLE
Override license files for highline

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -140,6 +140,7 @@ module LicenseScout
         ["rb-inotify", "MIT", nil],
         ["chef-web-core", "Apache-2.0", nil],
         ["knife-opc", "Apache-2.0", nil],
+        ["highline", "Ruby", ["LICENSE"]],
         # Overrides that require file fetching from internet
         ["sfl", "Ruby", ["https://raw.githubusercontent.com/ujihisa/spawn-for-legacy/master/LICENCE.md"]],
         ["json_pure", nil, ["https://raw.githubusercontent.com/flori/json/master/README.md"]],


### PR DESCRIPTION
We want to use the option of Ruby licensing for highline so
don't copy the GPL 2.0 license file and instead copy the remote
Ruby license test.