### PR TITLE
Bump the timeout for command execution. 

### DIFF
--- a/lib/license_scout/net_fetcher.rb
+++ b/lib/license_scout/net_fetcher.rb
@@ -80,7 +80,7 @@ module LicenseScout
 
       begin
         options = {
-          :read_timeout => 60,
+          :read_timeout => 300,
         }
 
         open(from_url, options) do |f|


### PR DESCRIPTION
Specifically this is needed to successfully complete the perl dependency resolution which takes ~ 2:30 during Chef Server build.

/cc: @danielsdeleo 