### PR TITLE
Unicorn is under a Ruby 1.8 license

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -141,6 +141,7 @@ module LicenseScout
         ["chef-web-core", "Apache-2.0", nil],
         ["knife-opc", "Apache-2.0", nil],
         ["highline", "Ruby", ["LICENSE"]],
+        ["unicorn", "Ruby", ["LICENSE"]],
         # Overrides that require file fetching from internet
         ["sfl", "Ruby", ["https://raw.githubusercontent.com/ujihisa/spawn-for-legacy/master/LICENCE.md"]],
         ["json_pure", nil, ["https://raw.githubusercontent.com/flori/json/master/README.md"]],


### PR DESCRIPTION
We can use Unicorn under the Ruby 1.8 license as an alternative
to GPL-3.0