### PR TITLE
Override license information of ibrowse under erland_rebar.

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -295,6 +295,7 @@ module LicenseScout
         ["quickrand", "BSD-2-Clause", ["https://raw.githubusercontent.com/okeuday/quickrand/master/README.markdown"]],
         ["rabbit_common", "MPL-2.0", ["https://raw.githubusercontent.com/muxspace/rabbit_common/master/include/rabbit_msg_store.hrl"]],
         ["uuid", "BSD-2-Clause", ["https://raw.githubusercontent.com/okeuday/uuid/master/README.markdown"]],
+        ["ibrowse", "BSD-2-Clause", nil],
       ].each do |override_data|
         override_license "erlang_rebar", override_data[0] do |version|
           {}.tap do |d|


### PR DESCRIPTION
```
Failing the build because :fatal_licensing_warnings is set in the configuration.
Error(s):

    Dependency 'ibrowse' version '8f3f6a3a30730b193cc340a8885a960586dc98de' under 'erlang_rebar' is missing license information.
    Dependency 'ibrowse' version '8f3f6a3a30730b193cc340a8885a960586dc98de' under 'erlang_rebar' is missing license information.
    Dependency 'ibrowse' version '8f3f6a3a30730b193cc340a8885a960586dc98de' under 'erlang_rebar' is missing license information.
```