### PR TITLE
Make berkshelf an optional dependency in order to be able to use license_scout on Solaris.

### DIFF
--- a/lib/license_scout/dependency_manager/berkshelf.rb
+++ b/lib/license_scout/dependency_manager/berkshelf.rb
@@ -15,8 +15,6 @@
 # limitations under the License.
 #
 
-require "berkshelf"
-
 require "license_scout/dependency_manager/base"
 
 module LicenseScout
@@ -27,11 +25,25 @@ module LicenseScout
         "chef_berkshelf"
       end
 
+      def berkshelf_available?
+        begin
+          require "berkshelf"
+        rescue LoadError
+          return false
+        end
+
+        true
+      end
+
       def detected?
         File.exists?(berksfile_path) && File.exists?(lockfile_path)
       end
 
       def dependencies
+        if !berkshelf_available?
+          raise LicenseScout::Exceptions::Error.new "Project at '#{project_dir}' is a Berkshelf project but berkshelf gem is not available in your bundle. Add berkshelf to your bundle in order to collect licenses for this project."
+        end
+
         dependencies = []
         cookbook_dependencies = nil
 

--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -37,11 +37,18 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ffi-yajl",         "~> 2.2"
   spec.add_dependency "mixlib-shellout",  "~> 2.2"
-  spec.add_dependency "berkshelf",        "~> 4.3"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rb-readline"
+
+  # We do not have berkshelf as a dependency because some of its dependencies
+  # can not be installed on uncommon platforms like Solaris which we need to
+  # support. If a project needs to collect license information for a berkshelf
+  # project it needs to include it seperately in its gem bundle. We have a nice
+  # error message when they do not. But we add berkshelf as a development
+  # dependency so that we can run our tests.
+  spec.add_development_dependency "berkshelf", "~> 4.3"
 end

--- a/spec/license_scout/dependency_manager/berkshelf_spec.rb
+++ b/spec/license_scout/dependency_manager/berkshelf_spec.rb
@@ -110,6 +110,18 @@ RSpec.describe(LicenseScout::DependencyManager::Berkshelf) do
 
     end
 
+    describe "when berkshelf is not available" do
+      before do
+        expect(berkshelf).to receive(:require).with("berkshelf") do
+          raise LoadError
+        end
+      end
+
+      it "raises an error" do
+        expect { berkshelf.dependencies }.to raise_error(LicenseScout::Exceptions::Error, /berkshelf gem is not available/)
+      end
+    end
+
     describe "when given license overrides" do
       let(:overrides) do
         LicenseScout::Overrides.new do


### PR DESCRIPTION
/cc: @danielsdeleo @ryancragun 

This PR makes berkshelf an optional dependency so that we can use license_scout on Solaris. When it is not an optional dependency trying to install license_scout gem on Solaris will fail when trying to build one of the native extensions of a gem that berkshelf pulls in. See below for an example error:

http://manhattan.ci.chef.co/job/angry-omnibus-toolchain-build/architecture=sun4v,platform=solaris-10,project=angry-omnibus-toolchain,role=builder/123/console