### PR TITLE
added overrides for new chef dependencies

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -148,6 +148,10 @@ module LicenseScout
         ["highline", "Ruby", ["LICENSE"]],
         ["unicorn", "Ruby", ["LICENSE"]],
         ["winrm-fs", "Apache-2.0", nil],
+        ["codecov", "MIT", nil],
+        ["net-http-persistent", "MIT", ["README.rdoc"]],
+        ["net-http-pipeline", "MIT", ["README.txt"]],
+        ["websocket", "MIT", ["README.md"]],
         # Overrides that require file fetching from internet
         ["sfl", "Ruby", ["https://raw.githubusercontent.com/ujihisa/spawn-for-legacy/master/LICENCE.md"]],
         ["json_pure", nil, ["https://raw.githubusercontent.com/flori/json/master/README.md"]],
@@ -195,6 +199,8 @@ module LicenseScout
         ["unicorn-rails", "MIT", ["https://raw.githubusercontent.com/samuelkadolph/unicorn-rails/master/LICENSE"]],
         ["hoe", "MIT", ["https://raw.githubusercontent.com/seattlerb/hoe/master/README.rdoc"]],
         ["rubyzip", nil, ["https://raw.githubusercontent.com/rubyzip/rubyzip/master/README.md"]],
+        ["url", nil, ["https://raw.githubusercontent.com/tal/URL/master/LICENSE"]],
+
       ].each do |override_data|
         override_license "ruby_bundler", override_data[0] do |version|
           {}.tap do |d|


### PR DESCRIPTION
These are getting pulled in at build time, when Chef Server is building
the Chef component.

Note that 4 bundler tests were failing locally before any changes due to missing `bundler/setup` in `_bundler_script.rb` - they fail with our without the bundler gem explicitly installed in the system, and whether or not I'm using bundle exec to run the tests. 

Signed-off-by: Marc Paradise <marc@chef.io>