### PR TITLE
Missing overrides to make chef-server build green.

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -148,7 +148,7 @@ module LicenseScout
         ["highline", "Ruby", ["LICENSE"]],
         ["unicorn", "Ruby", ["LICENSE"]],
         ["winrm-fs", "Apache-2.0", nil],
-        ["codecov", "MIT", nil],
+        ["codecov", "MIT", "https://raw.githubusercontent.com/codecov/codecov-ruby/master/LICENSE.txt"],
         ["net-http-persistent", "MIT", ["README.rdoc"]],
         ["net-http-pipeline", "MIT", ["README.txt"]],
         ["websocket", "MIT", ["README.md"]],
@@ -199,8 +199,7 @@ module LicenseScout
         ["unicorn-rails", "MIT", ["https://raw.githubusercontent.com/samuelkadolph/unicorn-rails/master/LICENSE"]],
         ["hoe", "MIT", ["https://raw.githubusercontent.com/seattlerb/hoe/master/README.rdoc"]],
         ["rubyzip", nil, ["https://raw.githubusercontent.com/rubyzip/rubyzip/master/README.md"]],
-        ["url", nil, ["https://raw.githubusercontent.com/tal/URL/master/LICENSE"]],
-
+        ["url", "MIT", ["https://raw.githubusercontent.com/tal/URL/master/LICENSE"]],
       ].each do |override_data|
         override_license "ruby_bundler", override_data[0] do |version|
           {}.tap do |d|


### PR DESCRIPTION
While turning on fatal licensing warnings on for Chef Server I have run into 3 errors:

```
    Dependency 'Class-Data-Inheritable' version '0.08' under 'perl_cpanm' is missing license files information.
    >> Found 99 dependencies for perl_cpanm. 98 OK, 1 with problems
    Dependency 'codecov' version '0.1.5' under 'ruby_bundler' is missing license files information.
    Dependency 'url' version '0.3.2' under 'ruby_bundler' is missing license information.
```

This PR fixes the ruby_bundler ones. #35 fixed the perl_cpanm ones.

/cc: @danielsdeleo @ryancragun