### PR TITLE
For overrides license_files should always be an array.

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -148,7 +148,7 @@ module LicenseScout
         ["highline", "Ruby", ["LICENSE"]],
         ["unicorn", "Ruby", ["LICENSE"]],
         ["winrm-fs", "Apache-2.0", nil],
-        ["codecov", "MIT", "https://raw.githubusercontent.com/codecov/codecov-ruby/master/LICENSE.txt"],
+        ["codecov", "MIT", ["https://raw.githubusercontent.com/codecov/codecov-ruby/master/LICENSE.txt"]],
         ["net-http-persistent", "MIT", ["README.rdoc"]],
         ["net-http-pipeline", "MIT", ["README.txt"]],
         ["websocket", "MIT", ["README.md"]],


### PR DESCRIPTION
Missing Array in the overrides leads to this:

```
Encountered error(s) with project's licensing information.
Failing the build because :fatal_licensing_warnings is set in the configuration.
Error(s):

    Unexpected error while running license_scout for 'chef': 'undefined method `map' for #<String:0x007ff7e4ecea08>'

    If you are encountering missing license or missing license file errors for **transitive** dependencies, you can provide overrides for the missing information at https://github.com/chef/license_scout/blob/master/lib/license_scout/overrides.rb#L93
```

/cc: @danielsdeleo @ryancragun 