### PR TITLE
Update tweetnacl-js license filename

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -358,7 +358,7 @@ module LicenseScout
         # Persevere project which is administered under the Dojo foundation,
         # and all contributions require a Dojo CLA.
         ["json-schema", "BSD", ["https://raw.githubusercontent.com/dojo/dojo/master/LICENSE"]],
-        ["tweetnacl", "BSD", ["https://raw.githubusercontent.com/dchest/tweetnacl-js/master/COPYING.txt"]],
+        ["tweetnacl", "BSD", ["https://raw.githubusercontent.com/dchest/tweetnacl-js/master/PUBLIC_DOMAIN.txt"]],
         ["assert-plus", "MIT", ["README.md"]],
         ["sntp", "BSD-3-Clause", nil],
         ["node-uuid", "MIT", nil],


### PR DESCRIPTION
No longer at https://raw.githubusercontent.com/dchest/tweetnacl-js/master/COPYING.txt.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>