### PR TITLE
Add Sub-Quote to overrides

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -251,6 +251,7 @@ module LicenseScout
         ["base", "Perl-5", ["http://www.perlfoundation.org/attachment/legal/artistic-2_0.txt"]],
         ["Encode", nil, ["AUTHORS"]],
         ["Moo", nil, ["README"]],
+        ["Sub-Quote", nil, ["README"]],
         ["Role-Tiny", nil, ["README"]],
         ["Try-Tiny", nil, ["LICENCE"]],
         ["Module-Metadata", nil, ["LICENCE"]],


### PR DESCRIPTION
Moo has split off [Sub-Quote](https://github.com/moose/Moo/commit/dafb860f91ab7c4ccf2604e7cf5de53abeb404ad). This seems to be somewhere in the dependency tree of sqitch, but it's not apparent (to me at least -- [see here](https://github.com/theory/sqitch/blob/v0.973/dist/sqitch.spec)).