### PR TITLE
Update 2nd crypto-browserify location in overrides

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -620,7 +620,7 @@ module LicenseScout
         ["require-uncached", nil, ["readme.md"]],
         ["rework", "MIT", ["Readme.md"]],
         ["rework-visit", "MIT", ["Readme.md"]],
-        ["ripemd160", "MIT", ["https://raw.githubusercontent.com/crypto-browserify/ripemd160/master/LICENSE.md"]],
+        ["ripemd160", "MIT", ["https://raw.githubusercontent.com/crypto-browserify/ripemd160/master/LICENSE"]],
         ["rx-lite", nil, ["readme.md"]],
         ["select", "MIT", ["readme.md"]],
         ["source-list-map", nil, ["README.md"]],


### PR DESCRIPTION
https://raw.githubusercontent.com/crypto-browserify/ripemd160/master/LICENSE.md was updated to https://raw.githubusercontent.com/crypto-browserify/ripemd160/master/LICENSE