### PR TITLE
[CON-535] Adding override for slack-notifier gem

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -208,6 +208,7 @@ module LicenseScout
         ["inspec-msccm", nil, ["https://www.chef.io/online-master-agreement/"]],
         ["inspec-scap", nil, ["https://www.chef.io/online-master-agreement/"]],
         ["aws-sigv4", "MIT", ["https://raw.githubusercontent.com/cmdrkeene/aws4/master/readme.md"]],
+        ["slack-notifier", "MIT", ["https://raw.githubusercontent.com/stevenosloan/slack-notifier/master/LICENSE"]],
       ].each do |override_data|
         override_license "ruby_bundler", override_data[0] do |version|
           {}.tap do |d|


### PR DESCRIPTION
The slack-notifier gem contents do not contain the license file itself,
so an override is necessary.