### PR TITLE
Workaround rebar 3.3.5 (used by chef-server)

### DIFF
--- a/lib/license_scout/dependency_manager/rebar.rb
+++ b/lib/license_scout/dependency_manager/rebar.rb
@@ -62,7 +62,8 @@ module LicenseScout
           next if File.directory?(File.join(project_dir, "apps", dep_name))
 
           # Or skip if the dep name is the project name
-          next if File.exist?(File.join(project_dir, "_build/default/rel", dep_name))
+          next if File.exist?(File.join(project_dir, "_build/default/rel", dep_name)) # rebar2, old rebar3
+          next if File.basename(project_dir) == dep_name # ^ rebar 3.3.5 doesn't create that
 
           # While determining the dependency version we first check the cache we
           # built from rebar.lock for the dependencies that come via 'pkg'


### PR DESCRIPTION
It seems `_build/default/rel/<projectname>` doesn't exist anymore with
the most recent rebar3 version. This makes license_scout exit with

    Dependency 'bookshelf' version 'dff0d7d4501380f9e052cab016e7295f43e10da5' under 'erlang_rebar' is missing license information.
    Dependency 'bookshelf' version 'dff0d7d4501380f9e052cab016e7295f43e10da5' under 'erlang_rebar' is missing license files information.
    >> Found 20 dependencies for erlang_rebar. 19 OK, 1 with problems

With this change, the "ignore dep_name if it's the project's name" logic
gets a small addition.

Due to incompatibilities with rebar3's rebar.lock when hex.pm packages
are used, further work in this are is planned (making this workaround
obsolete).

Signed-off-by: Stephan Renatus <srenatus@chef.io>