### PR TITLE
Add nokogiri license override

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -209,6 +209,7 @@ module LicenseScout
         ["inspec-scap", nil, ["https://www.chef.io/online-master-agreement/"]],
         ["aws-sigv4", "MIT", ["https://raw.githubusercontent.com/cmdrkeene/aws4/master/readme.md"]],
         ["slack-notifier", "MIT", ["https://raw.githubusercontent.com/stevenosloan/slack-notifier/master/LICENSE"]],
+        ["nokogiri", "MIT", ["https://raw.githubusercontent.com/sparklemotion/nokogiri/master/LICENSE.md"]],
       ].each do |override_data|
         override_license "ruby_bundler", override_data[0] do |version|
           {}.tap do |d|


### PR DESCRIPTION
Nokogiri changed it's license file location causing builds to fail. This change adds an override to the new license file.

```
  [Builder: nokogiri] I | 2017-02-13T09:03:23+00:00 | Finished build
              [Licensing] I | 2017-02-13T09:03:23+00:00 | Retrying failed download due to 404 Not Found (5 retries left)...
              [Licensing] I | 2017-02-13T09:03:24+00:00 | Retrying failed download due to 404 Not Found (4 retries left)...
              [Licensing] I | 2017-02-13T09:03:24+00:00 | Retrying failed download due to 404 Not Found (3 retries left)...
              [Licensing] I | 2017-02-13T09:03:24+00:00 | Retrying failed download due to 404 Not Found (2 retries left)...
              [Licensing] I | 2017-02-13T09:03:25+00:00 | Retrying failed download due to 404 Not Found (1 retries left)...
              [Licensing] E | 2017-02-13T09:03:25+00:00 | Download failed - OpenURI::HTTPError!
              [Licensing] W | 2017-02-13T09:03:25+00:00 | Can not download license file 'https://github.com/sparklemotion/nokogiri/blob/master/LICENSE.txt' for software 'nokogiri'.
```