### PR TITLE
Add performance now override

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -664,6 +664,7 @@ module LicenseScout
         ["web-animations-js", "Apache-2.0", ["https://raw.githubusercontent.com/web-animations/web-animations-js/dev/COPYING"]],
         ["electron-to-chromium", nil, [canonical("ISC")]],
         ["debug", "MIT", ["https://raw.githubusercontent.com/visionmedia/debug/master/LICENSE"]],
+        ["performance-now", "MIT", ["https://raw.githubusercontent.com/braveg1rl/performance-now/master/license.txt"]],
       ].each do |override_data|
         override_license "js_npm", override_data[0] do |version|
           {}.tap do |d|


### PR DESCRIPTION
fixes:
```
              [Licensing] W | 2017-03-06T18:36:34+00:00 | Dependency 'performance-now' version '0.2.0' under 'js_npm' is missing license files information.
              [Licensing] W | 2017-03-06T18:36:34+00:00 | >> Found 846 dependencies for js_npm. 845 OK, 1 with problems
Encountered error(s) with project's licensing information.
Failing the build because :fatal_licensing_warnings is set in the configuration.
Error(s):

    Dependency 'performance-now' version '0.2.0' under 'js_npm' is missing license files information.
    >> Found 846 dependencies for js_npm. 845 OK, 1 with problems
    If you are encountering missing license or missing license file errors for **transitive** dependencies, you can provide overrides for the missing information at https://github.com/chef/license_scout/blob/master/lib/license_scout/overrides.rb#L93
```