### PR TITLE
add support for glide projects

### DIFF
--- a/lib/license_scout/dependency_manager.rb
+++ b/lib/license_scout/dependency_manager.rb
@@ -19,6 +19,7 @@ require "license_scout/dependency_manager/bundler"
 require "license_scout/dependency_manager/rebar"
 require "license_scout/dependency_manager/cpanm"
 require "license_scout/dependency_manager/godep"
+require "license_scout/dependency_manager/glide"
 require "license_scout/dependency_manager/berkshelf"
 require "license_scout/dependency_manager/npm"
 require "license_scout/dependency_manager/manual"
@@ -26,7 +27,7 @@ require "license_scout/dependency_manager/manual"
 module LicenseScout
   module DependencyManager
     def self.implementations
-      [Bundler, Rebar, Cpanm, Berkshelf, NPM, Godep, Manual]
+      [Bundler, Rebar, Cpanm, Berkshelf, NPM, Godep, Glide, Manual]
     end
   end
 end

--- a/lib/license_scout/dependency_manager/glide.rb
+++ b/lib/license_scout/dependency_manager/glide.rb
@@ -46,9 +46,9 @@ module LicenseScout
         pkg_import_name = import_field["name"]
         pkg_file_name = pkg_import_name.tr("/", "_")
         pkg_version = import_field["version"]
-        license = options.overrides.license_for("go_godep", pkg_import_name, pkg_version)
+        license = options.overrides.license_for("go", pkg_import_name, pkg_version)
 
-        override_license_files = options.overrides.license_files_for("go_godep", pkg_import_name, pkg_version)
+        override_license_files = options.overrides.license_files_for("go", pkg_import_name, pkg_version)
         if override_license_files.empty?
           license_files = find_license_files_for_package_in_gopath(pkg_import_name)
         else

--- a/lib/license_scout/dependency_manager/glide.rb
+++ b/lib/license_scout/dependency_manager/glide.rb
@@ -1,0 +1,79 @@
+#
+# Copyright:: Copyright 2017, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "yaml"
+require "license_scout/dependency_manager/base"
+
+module LicenseScout
+  module DependencyManager
+    class Glide < Base
+
+      def name
+        "go_glide"
+      end
+
+      def detected?
+        File.exist?(glide_yaml)
+      end
+
+      def dependencies
+        unless File.file?(glide_yaml_locked)
+          raise "Detected Go/Glide project that is missing its \"glide.lock\" "\
+                "file in #{project_dir}"
+        end
+
+        deps = YAML.load(File.read(glide_yaml_locked))
+        deps["imports"].map { |i| add_glide_dep(i) }
+      end
+
+      private
+
+      def add_glide_dep(import_field)
+        pkg_import_name = import_field["name"]
+        pkg_file_name = pkg_import_name.tr("/", "_")
+        pkg_version = import_field["version"]
+        license = options.overrides.license_for("go_godep", pkg_import_name, pkg_version)
+
+        override_license_files = options.overrides.license_files_for("go_godep", pkg_import_name, pkg_version)
+        if override_license_files.empty?
+          license_files = find_license_files_for_package_in_gopath(pkg_import_name)
+        else
+          license_files = override_license_files.resolve_locations(gopath(pkg_import_name))
+        end
+
+        create_dependency(pkg_file_name, pkg_version, license, license_files)
+      end
+
+      def glide_yaml
+        File.join(project_dir, "glide.yaml")
+      end
+
+      def glide_yaml_locked
+        File.join(project_dir, "glide.lock")
+      end
+
+      def gopath(pkg)
+        "#{ENV['GOPATH']}/src/#{pkg}"
+      end
+
+      def find_license_files_for_package_in_gopath(pkg)
+        root_files = Dir["#{gopath(pkg)}/*"]
+        root_files.select { |f| POSSIBLE_LICENSE_FILES.include?(File.basename(f)) }
+      end
+    end
+  end
+end

--- a/lib/license_scout/dependency_manager/godep.rb
+++ b/lib/license_scout/dependency_manager/godep.rb
@@ -39,9 +39,9 @@ module LicenseScout
           pkg_import_name = pkg_info["ImportPath"]
           pkg_file_name = pkg_import_name.tr("/", "_")
           pkg_version = pkg_info["Comment"] || pkg_info["Rev"]
-          license = options.overrides.license_for(name, pkg_import_name, pkg_version)
+          license = options.overrides.license_for("go", pkg_import_name, pkg_version)
 
-          override_license_files = options.overrides.license_files_for(name, pkg_import_name, pkg_version)
+          override_license_files = options.overrides.license_files_for("go", pkg_import_name, pkg_version)
           if override_license_files.empty?
             license_files = find_license_files_for_package_in_gopath(pkg_import_name)
           else

--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -723,7 +723,7 @@ module LicenseScout
         ["gopkg.in/tylerb/graceful.v1", "MIT", ["https://raw.githubusercontent.com/tylerb/graceful/v1.2.13/LICENSE"]],
         ["gopkg.in/yaml.v2", "Apache-2.0", ["https://raw.githubusercontent.com/go-yaml/yaml/v2/LICENSE"]],
       ].each do |override_data|
-        override_license "go_godep", override_data[0] do |version|
+        override_license "go", override_data[0] do |version|
           {}.tap do |d|
             d[:license] = override_data[1] if override_data[1]
             d[:license_files] = override_data[2] if override_data[2]

--- a/spec/fixtures/glide/glide.lock
+++ b/spec/fixtures/glide/glide.lock
@@ -1,0 +1,9 @@
+hash: 34aa0aaadbd1a145344edd0b60b0054eff39e913db49238fbfa7ca038cbd7cab
+updated: 2017-05-05T11:00:34.451210773+02:00
+imports:
+- name: github.com/dep/a
+  version: rev0
+- name: github.com/dep/b
+  version: rev1
+- name: github.com/dep/c/subdir
+  version: rev2

--- a/spec/fixtures/glide/glide.yaml
+++ b/spec/fixtures/glide/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/chef/chef/chef
+import:
+- package: github.com/dep/a
+- package: gopkg.in/olivere/elastic.v3

--- a/spec/license_scout/dependency_manager/glide_spec.rb
+++ b/spec/license_scout/dependency_manager/glide_spec.rb
@@ -1,0 +1,137 @@
+#
+# Copyright:: Copyright 2017, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "license_scout/dependency_manager/glide"
+require "license_scout/overrides"
+require "license_scout/options"
+
+RSpec.describe(LicenseScout::DependencyManager::Glide) do
+
+  subject(:glide) do
+    described_class.new(project_dir, LicenseScout::Options.new(
+      overrides: overrides
+    ))
+  end
+
+  let(:overrides) { LicenseScout::Overrides.new(exclude_default: true) }
+
+  let(:project_dir) { File.join(SPEC_FIXTURES_DIR, "glide") }
+
+  it "has a name" do
+    expect(glide.name).to eq("go_glide")
+  end
+
+  it "has a project directory" do
+    expect(glide.project_dir).to eq(project_dir)
+  end
+
+  describe "when run in a non-glide project dir" do
+    let(:project_dir) { File.join(SPEC_FIXTURES_DIR, "no_dependency_manager") }
+
+    it "does not detect the project" do
+      expect(glide.detected?).to eq(false)
+    end
+  end
+
+  describe "when run in a glide-only project dir" do
+    let(:project_dir) { File.join(SPEC_FIXTURES_DIR, "godep") }
+
+    it "does not detect the project" do
+      expect(glide.detected?).to eq(false)
+    end
+  end
+
+  describe "when run in a glide project dir" do
+    before do
+      ENV["GOPATH"] = File.join(SPEC_FIXTURES_DIR, "godeps_gopath" )
+    end
+
+    it "does detects the project" do
+      expect(glide.detected?).to eq(true)
+    end
+
+    it "detects the dependencies and their details correctly" do
+      dependencies = glide.dependencies
+
+      # Make sure we have the right count
+      expect(dependencies.length).to eq(3)
+
+      dep_a = dependencies.select { |d| d.name == "github.com_dep_a" }
+      dep_b = dependencies.select { |d| d.name == "github.com_dep_b" }
+      dep_c = dependencies.select { |d| d.name == "github.com_dep_c_subdir" }
+
+      expect(dep_a.length).to be(1)
+      expect(dep_a.first.version).to eq("rev0")
+      expect(dep_a.first.license).to eq(nil)
+      expect(dep_a.first.license_files.first).to end_with("fixtures/godeps_gopath/src/github.com/dep/a/LICENSE.txt")
+
+      expect(dep_b.length).to be(1)
+      expect(dep_b.first.version).to eq("rev1")
+      expect(dep_b.first.license).to eq(nil)
+      expect(dep_b.first.license_files).to eq([])
+
+      expect(dep_c.length).to be(1)
+      expect(dep_c.first.version).to eq("rev2")
+      expect(dep_c.first.license).to eq(nil)
+      expect(dep_c.first.license_files.first).to end_with("fixtures/godeps_gopath/src/github.com/dep/c/subdir/LICENSE")
+    end
+
+    describe "when given license overrides" do
+      let(:overrides) do
+        LicenseScout::Overrides.new do
+          override_license "go_godep", "github.com/dep/c/subdir" do |version|
+            {
+              license: "MIT",
+            }
+          end
+        end
+      end
+
+      it "takes overrides into account" do
+        dependencies = glide.dependencies
+        expect(dependencies.length).to eq(3)
+
+        dep_c = dependencies.find { |d| d.name == "github.com_dep_c_subdir" }
+        expect(dep_c.license).to eq("MIT")
+      end
+
+    end
+
+    describe "when given license file overrides" do
+      let(:overrides) do
+        LicenseScout::Overrides.new do
+          override_license "go_godep", "github.com/dep/c/subdir" do |_version|
+            {
+              license_files: %w{README LICENSE},
+            }
+          end
+
+        end
+      end
+
+      it "takes overrides into account" do
+        dependencies = glide.dependencies
+        expect(dependencies.length).to eq(3)
+
+        dep_c = dependencies.find { |d| d.name == "github.com_dep_c_subdir" }
+        expect(dep_c.license_files[0]).to end_with("fixtures/godeps_gopath/src/github.com/dep/c/subdir/README")
+        expect(dep_c.license_files[1]).to end_with("fixtures/godeps_gopath/src/github.com/dep/c/subdir/LICENSE")
+      end
+
+    end
+  end
+end

--- a/spec/license_scout/dependency_manager/glide_spec.rb
+++ b/spec/license_scout/dependency_manager/glide_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe(LicenseScout::DependencyManager::Glide) do
     describe "when given license overrides" do
       let(:overrides) do
         LicenseScout::Overrides.new do
-          override_license "go_godep", "github.com/dep/c/subdir" do |version|
+          override_license "go", "github.com/dep/c/subdir" do |version|
             {
               license: "MIT",
             }
@@ -114,7 +114,7 @@ RSpec.describe(LicenseScout::DependencyManager::Glide) do
     describe "when given license file overrides" do
       let(:overrides) do
         LicenseScout::Overrides.new do
-          override_license "go_godep", "github.com/dep/c/subdir" do |_version|
+          override_license "go", "github.com/dep/c/subdir" do |_version|
             {
               license_files: %w{README LICENSE},
             }

--- a/spec/license_scout/dependency_manager/godep_spec.rb
+++ b/spec/license_scout/dependency_manager/godep_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe(LicenseScout::DependencyManager::Godep) do
     describe "when given license overrides" do
       let(:overrides) do
         LicenseScout::Overrides.new do
-          override_license "go_godep", "github.com/dep/c/subdir" do |version|
+          override_license "go", "github.com/dep/c/subdir" do |version|
             {
               license: "MIT",
             }
@@ -108,7 +108,7 @@ RSpec.describe(LicenseScout::DependencyManager::Godep) do
     describe "when given license file overrides" do
       let(:overrides) do
         LicenseScout::Overrides.new do
-          override_license "go_godep", "github.com/dep/c/subdir" do |_version|
+          override_license "go", "github.com/dep/c/subdir" do |_version|
             {
               license_files: %w{README LICENSE},
             }


### PR DESCRIPTION
It requires `glide.yaml` and `glide.lock` to exist in the project directory. Dependencies may reference other types of Go projects, including Godep-driven projects.