### PR TITLE
Add Dockerfile and exit 2 on verification failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ COPY Gemfile Rakefile license_scout.gemspec /usr/src/app/license_scout/
 
 WORKDIR /usr/src/app/license_scout
 
-RUN bundle install --with=development
+RUN bundle install --without=development
 
 ENTRYPOINT ["./bin/license_scout"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM devchef/chefdk
+RUN apt-get update && apt-get install git -y
+
+COPY bin/ /usr/src/app/license_scout/bin/
+COPY lib/ /usr/src/app/license_scout/lib/
+COPY Gemfile Rakefile license_scout.gemspec /usr/src/app/license_scout/
+
+WORKDIR /usr/src/app/license_scout
+
+RUN bundle install --with=development
+
+ENTRYPOINT ["./bin/license_scout"]

--- a/bin/license_scout
+++ b/bin/license_scout
@@ -39,3 +39,5 @@ collector.run
 report = collector.issue_report
 
 puts report
+
+exit 2 if !report.empty?


### PR DESCRIPTION
This adds a Dockerfile and exits 2 when license_scout detects missing licenses, both of which we need in order to run this in our pipeline.

Signed-off-by: Christian Nunciato <cnunciato@chef.io>