### PR TITLE
Use a regular dev dep for chefstyle.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-group(:development, :test) do
-  gem "chefstyle", git: "https://github.com/chef/chefstyle.git", branch: "master"
-end

--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rb-readline"
+  spec.add_development_dependency "chefstyle"
 
   # We do not have berkshelf as a dependency because some of its dependencies
   # can not be installed on uncommon platforms like Solaris which we need to


### PR DESCRIPTION
This seems cleaner in general and saves 2-3 seconds when installing with the docker file in #84.