### PR TITLE
Don't require git to be installed for gemspec

### DIFF
--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Discovers license files of a project's dependencies."
   spec.homepage      = "https://github.com/chef/license_scout"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["LICENSE", "README.md", "{bin,erl_src,lib}/**/*"]
   spec.bindir        = "bin"
   spec.executables   = %w{license_scout}
   spec.require_paths = %w{lib}


### PR DESCRIPTION
This would make installing git unnecessary in the Dockerfile in #84.

If I run `rake build` and inspect the built gem before and after this PR, I don't get exactly the same list because there were files included that were not necessary for using the gem after installation.

BEFORE:
```
- ".gitignore"
- ".rspec"
- ".rubocop.yml"
- ".travis.yml"
- Gemfile
- LICENSE
- README.md
- Rakefile
- appveyor.yml
- bin/license_scout
- bin/rebar_lock_json
- erl_src/rebar_lock_json/.gitignore
- erl_src/rebar_lock_json/README.md
- erl_src/rebar_lock_json/rebar.config
- erl_src/rebar_lock_json/rebar.lock
- erl_src/rebar_lock_json/src/rebar_lock_json.app.src
- erl_src/rebar_lock_json/src/rebar_lock_json.erl
- lib/license_scout.rb
- lib/license_scout/canonical_licenses/BSD-2-Clause.txt
- lib/license_scout/canonical_licenses/BSD-3-Clause.txt
- lib/license_scout/canonical_licenses/BSD-4-Clause.txt
- lib/license_scout/canonical_licenses/ISC.txt
- lib/license_scout/canonical_licenses/MIT.txt
- lib/license_scout/collector.rb
- lib/license_scout/dependency.rb
- lib/license_scout/dependency_manager.rb
- lib/license_scout/dependency_manager/base.rb
- lib/license_scout/dependency_manager/berkshelf.rb
- lib/license_scout/dependency_manager/bundler.rb
- lib/license_scout/dependency_manager/bundler/LICENSE.md
- lib/license_scout/dependency_manager/bundler/_bundler_script.rb
- lib/license_scout/dependency_manager/cpanm.rb
- lib/license_scout/dependency_manager/glide.rb
- lib/license_scout/dependency_manager/godep.rb
- lib/license_scout/dependency_manager/json/README.md
- lib/license_scout/dependency_manager/manual.rb
- lib/license_scout/dependency_manager/npm.rb
- lib/license_scout/dependency_manager/rebar.rb
- lib/license_scout/exceptions.rb
- lib/license_scout/license_file_analyzer.rb
- lib/license_scout/license_file_analyzer/any_matcher.rb
- lib/license_scout/license_file_analyzer/definitions.rb
- lib/license_scout/license_file_analyzer/header_matcher.rb
- lib/license_scout/license_file_analyzer/matcher.rb
- lib/license_scout/license_file_analyzer/template.rb
- lib/license_scout/license_file_analyzer/templates/Apache2-short.txt
- lib/license_scout/license_file_analyzer/templates/Apache2.txt
- lib/license_scout/license_file_analyzer/templates/BSD-2-Clause-bullets.txt
- lib/license_scout/license_file_analyzer/templates/BSD-2-Clause.txt
- lib/license_scout/license_file_analyzer/templates/BSD-3-Clause-alt-format.txt
- lib/license_scout/license_file_analyzer/templates/BSD-3-Clause.txt
- lib/license_scout/license_file_analyzer/templates/BSD.txt
- lib/license_scout/license_file_analyzer/templates/EPLICENSE.txt
- lib/license_scout/license_file_analyzer/templates/GPL-2.0.txt
- lib/license_scout/license_file_analyzer/templates/GPL-3.0.txt
- lib/license_scout/license_file_analyzer/templates/ISC.txt
- lib/license_scout/license_file_analyzer/templates/LGPL-3.0.txt
- lib/license_scout/license_file_analyzer/templates/MIT.txt
- lib/license_scout/license_file_analyzer/templates/MPL2.txt
- lib/license_scout/license_file_analyzer/templates/Python-2.0.txt
- lib/license_scout/license_file_analyzer/templates/Ruby.txt
- lib/license_scout/license_file_analyzer/text.rb
- lib/license_scout/net_fetcher.rb
- lib/license_scout/options.rb
- lib/license_scout/overrides.rb
- lib/license_scout/reporter.rb
- lib/license_scout/version.rb
- license_scout.gemspec
```

AFTER:
```
- LICENSE
- README.md
- bin/license_scout
- bin/rebar_lock_json
- erl_src/rebar_lock_json/README.md
- erl_src/rebar_lock_json/rebar.config
- erl_src/rebar_lock_json/rebar.lock
- erl_src/rebar_lock_json/src/rebar_lock_json.app.src
- erl_src/rebar_lock_json/src/rebar_lock_json.erl
- lib/license_scout.rb
- lib/license_scout/canonical_licenses/BSD-2-Clause.txt
- lib/license_scout/canonical_licenses/BSD-3-Clause.txt
- lib/license_scout/canonical_licenses/BSD-4-Clause.txt
- lib/license_scout/canonical_licenses/ISC.txt
- lib/license_scout/canonical_licenses/MIT.txt
- lib/license_scout/collector.rb
- lib/license_scout/dependency.rb
- lib/license_scout/dependency_manager.rb
- lib/license_scout/dependency_manager/base.rb
- lib/license_scout/dependency_manager/berkshelf.rb
- lib/license_scout/dependency_manager/bundler.rb
- lib/license_scout/dependency_manager/bundler/LICENSE.md
- lib/license_scout/dependency_manager/bundler/_bundler_script.rb
- lib/license_scout/dependency_manager/cpanm.rb
- lib/license_scout/dependency_manager/glide.rb
- lib/license_scout/dependency_manager/godep.rb
- lib/license_scout/dependency_manager/json/README.md
- lib/license_scout/dependency_manager/manual.rb
- lib/license_scout/dependency_manager/npm.rb
- lib/license_scout/dependency_manager/rebar.rb
- lib/license_scout/exceptions.rb
- lib/license_scout/license_file_analyzer.rb
- lib/license_scout/license_file_analyzer/any_matcher.rb
- lib/license_scout/license_file_analyzer/definitions.rb
- lib/license_scout/license_file_analyzer/header_matcher.rb
- lib/license_scout/license_file_analyzer/matcher.rb
- lib/license_scout/license_file_analyzer/template.rb
- lib/license_scout/license_file_analyzer/templates/Apache2-short.txt
- lib/license_scout/license_file_analyzer/templates/Apache2.txt
- lib/license_scout/license_file_analyzer/templates/BSD-2-Clause-bullets.txt
- lib/license_scout/license_file_analyzer/templates/BSD-2-Clause.txt
- lib/license_scout/license_file_analyzer/templates/BSD-3-Clause-alt-format.txt
- lib/license_scout/license_file_analyzer/templates/BSD-3-Clause.txt
- lib/license_scout/license_file_analyzer/templates/BSD.txt
- lib/license_scout/license_file_analyzer/templates/EPLICENSE.txt
- lib/license_scout/license_file_analyzer/templates/GPL-2.0.txt
- lib/license_scout/license_file_analyzer/templates/GPL-3.0.txt
- lib/license_scout/license_file_analyzer/templates/ISC.txt
- lib/license_scout/license_file_analyzer/templates/LGPL-3.0.txt
- lib/license_scout/license_file_analyzer/templates/MIT.txt
- lib/license_scout/license_file_analyzer/templates/MPL2.txt
- lib/license_scout/license_file_analyzer/templates/Python-2.0.txt
- lib/license_scout/license_file_analyzer/templates/Ruby.txt
- lib/license_scout/license_file_analyzer/text.rb
- lib/license_scout/net_fetcher.rb
- lib/license_scout/options.rb
- lib/license_scout/overrides.rb
- lib/license_scout/reporter.rb
- lib/license_scout/version.rb
```