### PR TITLE
Dockerfile no longer requires git.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM devchef/chefdk
-RUN apt-get update && apt-get install git -y
 
 COPY bin/ /usr/src/app/license_scout/bin/
 COPY lib/ /usr/src/app/license_scout/lib/


### PR DESCRIPTION
This was a followup to #87 that should have been in #84.