### PR TITLE
Add go overrides for elastic.v5 and pkg/errors

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -757,6 +757,8 @@ module LicenseScout
         ["gopkg.in/olivere/elastic.v3", "MIT", ["https://github.com/olivere/elastic/blob/v3.0.68/LICENSE"]],
         ["gopkg.in/tylerb/graceful.v1", "MIT", ["https://raw.githubusercontent.com/tylerb/graceful/v1.2.13/LICENSE"]],
         ["gopkg.in/yaml.v2", "Apache-2.0", ["https://raw.githubusercontent.com/go-yaml/yaml/v2/LICENSE"]],
+        ["gopkg.in/olivere/elastic.v5", "MIT", ["https://github.com/olivere/elastic/blob/v5.0.41/LICENSE"]],
+        ["github.com/pkg/errors", "BSD-2-Clause", ["https://github.com/pkg/errors/blob/master/LICENSE"]],
       ].each do |override_data|
         override_license "go", override_data[0] do |version|
           {}.tap do |d|


### PR DESCRIPTION
In an effort to fix this:
```
'3113f9b9ad37509fe5f8a0e5e91c96fdc4435e26' under 'go_glide' is missing license files information.
              [Licensing] W | 2017-06-20T19:18:33-04:00 | >> Found 55 dependencies for go_glide. 53 OK, 2 with problems
Encountered error(s) with project's licensing information.
Failing the build because :fatal_licensing_warnings is set in the configuration.
Error(s):

    Dependency 'github.com_pkg_errors' version 'c605e284fe17294bda444b34710735b29d1a9d90' under 'go_glide' is missing license information.
    Dependency 'github.com_pkg_errors' version 'c605e284fe17294bda444b34710735b29d1a9d90' under 'go_glide' is missing license files information.
    Dependency 'gopkg.in_olivere_elastic.v5' version '3113f9b9ad37509fe5f8a0e5e91c96fdc4435e26' under 'go_glide' is missing license information.
    Dependency 'gopkg.in_olivere_elastic.v5' version '3113f9b9ad37509fe5f8a0e5e91c96fdc4435e26' under 'go_glide' is missing license files information.
    >> Found 55 dependencies for go_glide. 53 OK, 2 with problems
    If you are encountering missing license or missing license file errors for **transitive** dependencies, you can provide overrides for the missing information at https://github.com/chef/license_scout/blob/master/lib/license_scout/overrides.rb#L93
```

cc @chef/compliance-team 