### PR TITLE
Add overrides for new visibility-web js dependencies.

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -354,6 +354,8 @@ module LicenseScout
 
       # js_npm
       [
+        ["copy-to-clipboard", nil, [canonical("MIT")]],
+        ["toggle-selection", nil, [canonical("MIT")]],
         ["isarray", nil, [canonical("MIT")]],
         ["array-filter", nil, [canonical("MIT")]],
         ["chokidar", nil, ["README.md"]],


### PR DESCRIPTION
Both of these list MIT as the license in their package metadata but do not include the license text, requiring an override.

https://github.com/sudodoki/copy-to-clipboard/blob/b6159db17b81373419bb38c088658c21e4af69e5/package.json#L17
https://github.com/sudodoki/toggle-selection/blob/466460c75ca40630d8de940490718247fce79a3e/package.json#L20