### PR TITLE
Remove accidental network calls from specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/spec/examples.txt

--- a/lib/license_scout/collector.rb
+++ b/lib/license_scout/collector.rb
@@ -44,7 +44,7 @@ module LicenseScout
     def run
       reset_license_manifest
 
-      if !File.exists?(project_dir)
+      if !File.exist?(project_dir)
         raise LicenseScout::Exceptions::ProjectDirectoryMissing.new(project_dir)
       end
       FileUtils.mkdir_p(output_dir) unless File.exist?(output_dir)

--- a/lib/license_scout/dependency_manager/berkshelf.rb
+++ b/lib/license_scout/dependency_manager/berkshelf.rb
@@ -36,7 +36,7 @@ module LicenseScout
       end
 
       def detected?
-        File.exists?(berksfile_path) && File.exists?(lockfile_path)
+        File.exist?(berksfile_path) && File.exist?(lockfile_path)
       end
 
       def dependencies

--- a/lib/license_scout/dependency_manager/bundler.rb
+++ b/lib/license_scout/dependency_manager/bundler.rb
@@ -39,7 +39,7 @@ module LicenseScout
         # that created issues with projects like oc_bifrost which is a rebar
         # project but have a Gemfile at its root to be able to run some rake
         # commands.
-        File.exists?(gemfile_path) && File.exists?(lockfile_path)
+        File.exist?(gemfile_path) && File.exist?(lockfile_path)
       end
 
       def dependency_data

--- a/lib/license_scout/net_fetcher.rb
+++ b/lib/license_scout/net_fetcher.rb
@@ -18,6 +18,7 @@
 require "open-uri"
 require "tmpdir"
 require "digest"
+require "socket" # Defines `SocketError`
 
 require "license_scout/exceptions"
 

--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -46,7 +46,7 @@ module LicenseScout
 
       def normalize_and_verify_path(license_location, dependency_root_dir)
         full_path = File.expand_path(license_location, dependency_root_dir)
-        if File.exists?(full_path)
+        if File.exist?(full_path)
           full_path
         else
           raise Exceptions::InvalidOverride, "Provided license file path '#{license_location}' can not be found under detected dependency path '#{dependency_root_dir}'."

--- a/spec/license_scout/dependency_manager/berkshelf_spec.rb
+++ b/spec/license_scout/dependency_manager/berkshelf_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe(LicenseScout::DependencyManager::Berkshelf) do
 
   let(:tmpdir) { Dir.mktmpdir }
 
-  let(:overrides) { LicenseScout::Overrides.new }
+  let(:overrides) { LicenseScout::Overrides.new(exclude_default: true) }
   let(:project_dir) { File.join(tmpdir, "berkshelf_project") }
 
   before do
@@ -124,7 +124,7 @@ RSpec.describe(LicenseScout::DependencyManager::Berkshelf) do
 
     describe "when given license overrides" do
       let(:overrides) do
-        LicenseScout::Overrides.new do
+        LicenseScout::Overrides.new(exclude_default: true) do
           override_license "chef_berkshelf", "windows" do |version|
             {
               license: "MIT",
@@ -149,7 +149,7 @@ RSpec.describe(LicenseScout::DependencyManager::Berkshelf) do
 
     describe "when given license file overrides" do
       let(:overrides) do
-        LicenseScout::Overrides.new do
+        LicenseScout::Overrides.new(exclude_default: true) do
           override_license "chef_berkshelf", "git" do |version|
             {
               license_files: ["README.md", "CHANGELOG.md"],
@@ -177,7 +177,7 @@ RSpec.describe(LicenseScout::DependencyManager::Berkshelf) do
 
     describe "when given both license and license file overrides" do
       let(:overrides) do
-        LicenseScout::Overrides.new do
+        LicenseScout::Overrides.new(exclude_default: true) do
           override_license "chef_berkshelf", "omnibus" do |version|
             {
               license: "MIT",

--- a/spec/license_scout/dependency_manager/npm_spec.rb
+++ b/spec/license_scout/dependency_manager/npm_spec.rb
@@ -140,6 +140,13 @@ RSpec.describe(LicenseScout::DependencyManager::NPM) do
 
       let(:overrides) { LicenseScout::Overrides.new() }
 
+      before do
+        allow(LicenseScout::NetFetcher).to receive(:new).and_call_original
+        allow(LicenseScout::NetFetcher).to receive(:cache) do |url|
+          LicenseScout::NetFetcher.new(url).cache_path
+        end
+      end
+
       it "fixes up dependencies with license metadata but no license files" do
         assert_plus_1_0_0 = npm.dependencies.find do |d|
           d.name == "assert-plus" && d.version = "1.0.0"

--- a/spec/license_scout/dependency_manager/rebar_spec.rb
+++ b/spec/license_scout/dependency_manager/rebar_spec.rb
@@ -17,6 +17,7 @@
 
 require "license_scout/dependency_manager/rebar"
 require "license_scout/overrides"
+require "license_scout/options"
 
 RSpec.describe(LicenseScout::DependencyManager::Rebar) do
 
@@ -72,11 +73,12 @@ RSpec.describe(LicenseScout::DependencyManager::Rebar) do
   let(:tmpdir) { Dir.mktmpdir }
 
   let(:overrides) do
-    o = LicenseScout::Overrides.new
+    o = LicenseScout::Overrides.new(exclude_default: true)
     # delete the default erlang overrides
     o.override_rules.delete("erlang_rebar")
     o
   end
+
   let(:project_dir) { File.join(tmpdir, "rebar_project") }
 
   after do
@@ -175,7 +177,7 @@ RSpec.describe(LicenseScout::DependencyManager::Rebar) do
 
     describe "when only license files are overridden." do
       let(:overrides) do
-        LicenseScout::Overrides.new() do
+        LicenseScout::Overrides.new(exclude_default: true) do
           override_license "erlang_rebar", "ej" do |version|
             {
               license_files: [ "Makefile" ], # pick any file from ej
@@ -202,7 +204,7 @@ RSpec.describe(LicenseScout::DependencyManager::Rebar) do
 
     describe "when overrides for both license file and type are given" do
       let(:overrides) do
-        LicenseScout::Overrides.new() do
+        LicenseScout::Overrides.new(exclude_default: true) do
           override_license "erlang_rebar", "ej" do |version|
             {
               license: "example-license",
@@ -226,7 +228,7 @@ RSpec.describe(LicenseScout::DependencyManager::Rebar) do
 
     describe "when overrides with missing license file paths are provided" do
       let(:overrides) do
-        LicenseScout::Overrides.new() do
+        LicenseScout::Overrides.new(exclude_default: true) do
           override_license "erlang_rebar", "ej" do |version|
             {
               license: "Apache",

--- a/spec/license_scout/net_fetcher_spec.rb
+++ b/spec/license_scout/net_fetcher_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe(LicenseScout::NetFetcher) do
   let(:tmpdir) { Dir.mktmpdir }
 
   before do
+    allow(described_class).to receive(:new).and_call_original
     FileUtils.rm_rf(fetcher.cache_dir)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,8 +82,6 @@ RSpec.configure do |config|
       and_raise("Network calls should be avoided. Maybe you forgot to pass `exclude_default: true` when creating the Overrides object?")
   end
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -92,7 +90,6 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
   config.filter_run_excluding :no_windows => true if !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
 
-=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
@@ -105,9 +102,8 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
 
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  config.warnings = true
+  # Berks and its deps create too much noise to enable warnings right now :(
+  #config.warnings = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
@@ -135,7 +131,6 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end
 
 SPEC_FIXTURES_DIR = File.expand_path("fixtures", File.dirname(__FILE__))


### PR DESCRIPTION
When we use real project names that exist in the overrides file, the tests will pull down license files from GitHub. I've fixed all cases of that I could detect here. In addition to being good hygiene for unit tests, this also avoids some test failure modes that are really confusing, especially for folks who are less familiar with the codebase.

Signed-off-by: Daniel DeLeo <dan@chef.io>