### PR TITLE
Provide instructions for fixing failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Dependency 'gopkg.in_yaml.v2' version '53feefa2559fb8dfa8d81baad31be332c97d6c77'
 >> Found 41 dependencies for go_godep. 40 OK, 1 with problems
 ```
 
+Detailed instructions for fixing licensing failures found by license_scout are now provided in the script's output. See [bin/license_scout](bin/license_scout) for more details.
+
 ## Contributing
 
 This project is maintained by the contribution guidelines identified for

--- a/bin/license_scout
+++ b/bin/license_scout
@@ -38,6 +38,42 @@ collector = LicenseScout::Collector.new(project_name, project_dir, output_dir, o
 collector.run
 report = collector.issue_report
 
-puts report
+unless report.empty?
+  puts report
 
-exit 2 if !report.empty?
+  puts <<-EXPLANATION
+
+How to fix this depends on what information license_scout was unable to
+determine:
+
+* If the package is missing license information, that means license_scout was
+  unable to determine which license the package was released under. Depending
+  on the package manager, this is usually specified in the package's metadata,
+  for example, in the gemspec file for rubygems or in the package.json for npm.
+  If you know which license a package was released under, MIT for example, you
+  can add an override in license_scout's overrides.rb file in the section for
+  the appropriate package manager like this:
+    ["package-name", "MIT", nil]
+
+* If the package is missing the license file, that means license_scout could not
+  find the license text in any of the places the license is typically found, for
+  example, in a file named LICENSE in the root of the package. If the package
+  includes the license text in a non standard location or in its source repo,
+  you can indicate this by adding an override in license_scout's overrides.rb
+  file in the section for the appropriate package manager like this:
+    ["package-name", nil, ["https://example.com/foocorp/package-name/master/LICENSE"]],
+
+  If you know that the package was released under one of the common software
+  licenses, MIT for example, but does not include the license text in packaged
+  releases or in its source repo, you can add an override in license_scout's
+  overrides.rb file in the section for the appropriate package manager like
+  this:
+    ["package-name", nil, [canonical("MIT")]]
+
+See the closed pull requests on the license_scout repo for examples of how to
+do this:
+https://github.com/chef/license_scout/pulls?q=is%3Apr+is%3Aclosed
+  EXPLANATION
+
+  exit 2
+end


### PR DESCRIPTION
Hello,

There have been a few instances lately of folks unfamiliar with license_scout encountering a failure after adding a new dependency and not knowing how to fix it. This is an attempt to provide some instruction when a failure occurs as part of CI, etc. 

After this PR, a failure using the `bin/license_scout` script will look like this:

```
Petes-MBP:automate-ui pete$ ../license_scout/bin/license_scout .
Dependency 'core-object' version '3.1.4' under 'js_npm' is missing license files information.
Dependency 'stdout-stream' version '1.4.0' under 'js_npm' is missing license information.
Dependency 'thunky' version '0.1.0' under 'js_npm' is missing license information.
Dependency 'thunky' version '0.1.0' under 'js_npm' is missing license files information.
>> Found 1035 dependencies for js_npm. 1032 OK, 3 with problems

How to fix this depends on what information license_scout was unable to
determine:

* If the package is missing license information, that means license_scout was
  unable to determine which license the package was released under. Depending
  on the package manager, this is usually specified in the package's metadata,
  for example, in the gemspec file for rubygems or in the package.json for npm.
  If you know which license a package was released under, MIT for example, you
  can add an override in license_scout's overrides.rb file in the section for
  the appropriate package manager like this:
    ["package-name", "MIT", nil]

* If the package is missing the license file, the means license_scout could not
  find the license text is any of the locations that typically exists, for
  example, in a file named LICENSE in the root of the package. If you know that
  the package was released under one of the common software licenses,
  MIT for example, you can add an override in license_scout's overrides.rb file
  in the section for the appropriate package manager like this:
    ["package-name", nil, [canonical("MIT")]]

See the closed pull requests on the license_scout repo for examples of how to
do this:
https://github.com/chef/license_scout/pulls?q=is%3Apr+is%3Aclosed
```

Since we know which package manager, package, and fields are missing we could be a lot smarter about this, ie, providing the exact code to copy-paste into overrides.rb, but this seemed like a good compromise without a ton of time invested.