### PR TITLE
add override for wallaby-webpack

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -805,6 +805,7 @@ module LicenseScout
         ["update-notifier", nil, ["readme.md"]],
         ["url-loader", nil, ["README.md"]],
         ["utila", nil, ["https://raw.githubusercontent.com/AriaMinaei/utila/master/LICENSE"]],
+        ["wallaby-webpack", nil, [canonical("MIT")]],
         ["watchpack", nil, ["https://raw.githubusercontent.com/webpack/watchpack/master/LICENSE"]],
         ["webpack-core", nil, ["README.md"]],
         ["webpack-dev-middleware", nil, [canonical("MIT")]],


### PR DESCRIPTION
Corresponded with the package author to confirm that this package uses an MIT license though it is missing a license file in its repo.