### PR TITLE
Golang dep scan files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 /spec/examples.txt
+/license-cache/

--- a/lib/license_scout/dependency_manager/dep.rb
+++ b/lib/license_scout/dependency_manager/dep.rb
@@ -51,11 +51,20 @@ module LicenseScout
             license_files = override_license_files.resolve_locations(gopath(pkg_import_name))
           end
 
+          if license.nil? && !license_files.empty?
+            license = scan_licenses(license_files)
+          end
+
           create_dependency(pkg_file_name, pkg_version, license, license_files)
         end
       end
 
       private
+
+      def scan_licenses(license_files)
+        found_license = LicenseScout::LicenseFileAnalyzer.find_by_text(IO.read(license_files.first))
+        found_license && found_license.short_name
+      end
 
       def root_dep_file
         File.join(project_dir, "Gopkg.lock")

--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -928,14 +928,7 @@ module LicenseScout
         ["google.golang.org/genproto", "BSD-3-Clause", ["https://raw.githubusercontent.com/golang/net/master/LICENSE"]],
         ["google.golang.org/grpc", "BSD-3-Clause", ["https://raw.githubusercontent.com/golang/net/master/LICENSE"]],
         ["github.com/schollz/closestmatch", "MIT", ["https://raw.githubusercontent.com/schollz/closestmatch/master/LICENSE"]],
-        ["github.com/fsnotify/fsnotify", "BSD-3-Clause", ["https://raw.githubusercontent.com/fsnotify/fsnotify/master/LICENSE"]],
-        ["github.com/magiconair/properties", "BSD-3-Clause", ["https://raw.githubusercontent.com/magiconair/properties/master/LICENSE"]],
-        ["github.com/pelletier/go-toml", "MIT", ["https://raw.githubusercontent.com/pelletier/go-toml/master/LICENSE"]],
         ["github.com/sirupsen/logrus", "MIT", ["https://raw.githubusercontent.com/sirupsen/logrus/master/LICENSE"]],
-        ["github.com/spf13/afero", "Apache-2.0", ["https://raw.githubusercontent.com/spf13/afero/master/LICENSE.txt"]],
-        ["github.com/spf13/cast", "MIT", ["https://raw.githubusercontent.com/spf13/cast/master/LICENSE"]],
-        ["github.com/spf13/jwalterweatherman", "MIT", ["https://raw.githubusercontent.com/spf13/jWalterWeatherman/master/LICENSE"]],
-        ["github.com/spf13/viper", "MIT", ["https://raw.githubusercontent.com/spf13/viper/master/LICENSE"]],
       ].each do |override_data|
         override_license "go", override_data[0] do |version|
           {}.tap do |d|

--- a/spec/fixtures/deps_gopath/src/github.com/foo/bar/LICENSE
+++ b/spec/fixtures/deps_gopath/src/github.com/foo/bar/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/spec/fixtures/license_analyzer_licenses/spf13-afero-apache2
+++ b/spec/fixtures/license_analyzer_licenses/spf13-afero-apache2
@@ -1,3 +1,7 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
    1. Definitions.

--- a/spec/license_scout/dependency_manager/dep_spec.rb
+++ b/spec/license_scout/dependency_manager/dep_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe(LicenseScout::DependencyManager::Dep) do
       expect(dep.detected?).to eq(true)
     end
 
-    it "detects the dependencies and their details correctly" do
+    it "detects the dependencies, finds license files, and scans license files for license type" do
       dependencies = dep.dependencies
       # Make sure we have the right count
       expect(dependencies.length).to eq(2)
@@ -68,7 +68,7 @@ RSpec.describe(LicenseScout::DependencyManager::Dep) do
 
       expect(dep_a.length).to be(1)
       expect(dep_a.first.version).to eq("a4973d9a4225417aecf5d450a9522f00c1f7130f")
-      expect(dep_a.first.license).to eq(nil)
+      expect(dep_a.first.license).to eq("Apache-2.0")
       expect(dep_a.first.license_files.first).to end_with("fixtures/deps_gopath/src/github.com/foo/bar/LICENSE")
 
 

--- a/spec/license_scout/license_file_analyzer_spec.rb
+++ b/spec/license_scout/license_file_analyzer_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe(LicenseScout::LicenseFileAnalyzer) do
     expect(described_class.find_by_text(license_file("hoax-apache2-short")).short_name).to eq("Apache-2.0")
   end
 
+  # This one is missing the last 2 lines of the standard file
+  it "detects the Apache 2.0 license in spf13/afero" do
+    expect(described_class.find_by_text(license_file("spf13-afero-apache2")).short_name).to eq("Apache-2.0")
+  end
+
   it "detects a MIT license with copyright holder filled in" do
     expect(described_class.find_by_text(license_file("eper-mit")).short_name).to eq("MIT")
   end


### PR DESCRIPTION
Since go's dependency management is based on pulling from git repos and doesn't have any metadata yet, we can only detect the license type for the happy cases by scanning the license files. So let's do that.