### PR TITLE
Add license override for automate-ui deps.

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -465,6 +465,7 @@ module LicenseScout
 
       # js_npm
       [
+        ["hock", "MIT", nil],
         ["known-css-properties", nil, [canonical("MIT")]],
         ["buffer-indexof", "MIT", nil],
         ["stdout-stream", "MIT", nil],


### PR DESCRIPTION
This package includes the MIT license text but does not indicate the license in the package metadata. I've opened a PR to add it, but in the meantime this needs an override.