### PR TITLE
Add override for aws-sdk-pricing

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -178,6 +178,7 @@ module LicenseScout
           aws-sdk-organizations
           aws-sdk-pinpoint
           aws-sdk-polly
+          aws-sdk-pricing
           aws-sdk-rds
           aws-sdk-redshift
           aws-sdk-rekognition


### PR DESCRIPTION
aws-sdk-pricing was recently split into a separate gem.  Adding override
to point it to the master AWS license file.

https://github.com/aws/aws-sdk-ruby/tree/master/gems/aws-sdk-pricing

Signed-off-by: Nolan Davidson <ndavidson@chef.io>