### PR TITLE
dep: check vendor dir for license files

### DIFF
--- a/lib/license_scout/dependency_manager/base.rb
+++ b/lib/license_scout/dependency_manager/base.rb
@@ -16,6 +16,7 @@
 #
 
 require "license_scout/dependency"
+require "license_scout/license_file_analyzer"
 
 module LicenseScout
   module DependencyManager

--- a/lib/license_scout/dependency_manager/dep.rb
+++ b/lib/license_scout/dependency_manager/dep.rb
@@ -46,7 +46,7 @@ module LicenseScout
 
           override_license_files = options.overrides.license_files_for("go", pkg_import_name, pkg_version)
           if override_license_files.empty?
-            license_files = find_license_files_for_package_in_gopath(pkg_import_name)
+            license_files = find_license_files_for_package_in_gopath_or_vendor_dir(pkg_import_name)
           else
             license_files = override_license_files.resolve_locations(gopath(pkg_import_name))
           end
@@ -74,8 +74,12 @@ module LicenseScout
         "#{ENV['GOPATH']}/src/#{pkg}"
       end
 
-      def find_license_files_for_package_in_gopath(pkg)
-        root_files = Dir["#{gopath(pkg)}/*"]
+      def vendor_dir(pkg = nil)
+        File.join(project_dir, "vendor/#{pkg}")
+      end
+
+      def find_license_files_for_package_in_gopath_or_vendor_dir(pkg)
+        root_files = Dir["#{gopath(pkg)}/*"] + Dir["#{vendor_dir(pkg)}/*"]
         root_files.select { |f| POSSIBLE_LICENSE_FILES.include?(File.basename(f)) }
       end
     end

--- a/spec/fixtures/dep/Gopkg.lock
+++ b/spec/fixtures/dep/Gopkg.lock
@@ -10,6 +10,12 @@
   revision = "edbef41beaacc2ee95e61af8faff04e67c01e268"
   version = "v5.0.45"
 
+[[projects]]
+  name = "github.com/f00/b4r"
+  packages = ["."]
+  revision = "edbef41beaacc2ee95e61af8faff04e67c01e268"
+  version = "v0.0.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1

--- a/spec/fixtures/dep/vendor/github.com/f00/b4r/LICENSE
+++ b/spec/fixtures/dep/vendor/github.com/f00/b4r/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 f00 (nonexistant)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/spec/license_scout/dependency_manager/dep_spec.rb
+++ b/spec/license_scout/dependency_manager/dep_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe(LicenseScout::DependencyManager::Dep) do
     it "detects the dependencies, finds license files, and scans license files for license type" do
       dependencies = dep.dependencies
       # Make sure we have the right count
-      expect(dependencies.length).to eq(2)
+      expect(dependencies.length).to eq(3)
 
       dep_a = dependencies.select { |d| d.name == "github.com_foo_bar" }
       dep_b = dependencies.select { |d| d.name == "gopkg.in_foo_baz" }
@@ -71,11 +71,22 @@ RSpec.describe(LicenseScout::DependencyManager::Dep) do
       expect(dep_a.first.license).to eq("Apache-2.0")
       expect(dep_a.first.license_files.first).to end_with("fixtures/deps_gopath/src/github.com/foo/bar/LICENSE")
 
-
       expect(dep_b.length).to be(1)
       expect(dep_b.first.version).to eq("v5.0.45")
       expect(dep_b.first.license).to eq(nil)
       expect(dep_b.first.license_files.first).to end_with("fixtures/deps_gopath/src/gopkg.in/foo/baz/LICENSE")
+    end
+
+    it "also checks vendor/ for license files" do
+      dependencies = dep.dependencies
+      expect(dependencies.length).to eq(3)
+
+      dep_c = dependencies.select { |d| d.name == "github.com_f00_b4r" }
+      puts dep_c
+      expect(dep_c.length).to be(1)
+      expect(dep_c.first.version).to eq("v0.0.1")
+      expect(dep_c.first.license).to eq("MIT")
+      expect(dep_c.first.license_files.first).to end_with("fixtures/dep/vendor/github.com/f00/b4r/LICENSE")
     end
 
     describe "when given license overrides" do
@@ -91,7 +102,7 @@ RSpec.describe(LicenseScout::DependencyManager::Dep) do
 
       it "takes overrides into account" do
         dependencies = dep.dependencies
-        expect(dependencies.length).to eq(2)
+        expect(dependencies.length).to eq(3)
 
         dep_b = dependencies.find { |d| d.name == "gopkg.in_foo_baz" }
         expect(dep_b.license).to eq("APACHE2")
@@ -113,7 +124,7 @@ RSpec.describe(LicenseScout::DependencyManager::Dep) do
 
       it "takes overrides into account" do
         dependencies = dep.dependencies
-        expect(dependencies.length).to eq(2)
+        expect(dependencies.length).to eq(3)
 
         dep_b = dependencies.find { |d| d.name == "gopkg.in_foo_baz" }
         expect(dep_b.license_files[0]).to end_with("fixtures/deps_gopath/src/gopkg.in/foo/baz/README")


### PR DESCRIPTION
When looking at #120, I've noticed that we're missing out big time on license_scout's analysis capabilities if we don't look into `vendor/`. However, this requires `vendor/` to be populated, either by

- tracking it via git, or
- running `dep ensure` _before_ `license_scout`