### PR TITLE
Add 1.x and 2.x release branches

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -6,6 +6,11 @@ github:
   version_tag_format: "v{{version}}"
   minor_bump_labels:
     - "Version: Bump Minor"
+  release_branch:
+    - master:
+        version_constraint: 2.*
+    - 1-stable:
+        version_constraint: 1.*
 
 rubygems:
   - license_scout


### PR DESCRIPTION
This is here to prep Expeditor to do the right things. When this is merged, we will create the `1-stable` branch and update the versions accordingly.

Signed-off-by: Tom Duffield <tom@chef.io>