### PR TITLE
Add exception for simplecov

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -353,6 +353,7 @@ module LicenseScout
         ["parslet", "MIT", ["https://raw.githubusercontent.com/kschiess/parslet/master/LICENSE"]],
         ["blankslate", "MIT", ["https://raw.githubusercontent.com/masover/blankslate/master/MIT-LICENSE"]],
         ["xml-simple", "Ruby", ["https://raw.githubusercontent.com/maik/xml-simple/master/README.md"]],
+        ["simplecov", "MIT", ["https://github.com/colszowka/simplecov/blob/master/MIT-LICENSE"]],
       ]
       (aws_sdk_gems + other_gems).each do |override_data|
         override_license "ruby_bundler", override_data[0] do |version|

--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -983,7 +983,7 @@ module LicenseScout
         ["github.com/spf13/jwalterweatherman", "MIT", ["https://raw.githubusercontent.com/spf13/jWalterWeatherman/master/LICENSE"]],
         ["github.com/spf13/viper", "MIT", ["https://raw.githubusercontent.com/spf13/viper/master/LICENSE"]],
         ["github.com/satori/go.uuid", "MIT", ["https://raw.githubusercontent.com/satori/go.uuid/master/LICENSE"]],
-        ["github.com/teambition/rrule-go", "MIT", ["https://raw.githubusercontent.com/teambition/rrule-go/master/LICENSE"]]
+        ["github.com/teambition/rrule-go", "MIT", ["https://raw.githubusercontent.com/teambition/rrule-go/master/LICENSE"]],
       ].each do |override_data|
         override_license "go", override_data[0] do |version|
           {}.tap do |d|

--- a/lib/license_scout/reporter.rb
+++ b/lib/license_scout/reporter.rb
@@ -39,7 +39,7 @@ module LicenseScout
 
         ok_deps, problem_deps = 0, 0
 
-        dependencies.sort { |a, b| a["name"] <=> b["name"] }.each do |dependency|
+        dependencies.sort_by { |a| a["name"] }.each do |dependency|
           dep_ok, problems = license_info_ok?(dependency_manager, dependency)
 
           if dep_ok

--- a/spec/license_scout/overrides_spec.rb
+++ b/spec/license_scout/overrides_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe(LicenseScout::Overrides) do
         library_map.each_key do |library_name|
           license_files = overrides.license_files_for(dep_manager, library_name, nil)
           if license_files.license_locations.any? { |location| location.include?("(\/\/|www\.)github.com") }
-            fail "You must use raw.githubusercontent.com instead of github.com for overrides. \n" +
-                 "Dependency type: #{dep_manager}\nDependency name: #{library_name}\nLicense location: #{license_files.license_locations}"
+            raise "You must use raw.githubusercontent.com instead of github.com for overrides. \n" +
+              "Dependency type: #{dep_manager}\nDependency name: #{library_name}\nLicense location: #{license_files.license_locations}"
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,6 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-
   # Global before each: prevent network calls via NetFetcher
   # By default LicenseScout::Overrides contains the default set of overrides,
   # any of which can configure the system to fetch a license file from the
@@ -112,7 +111,7 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
 
   # Print the 10 slowest examples and example groups at the


### PR DESCRIPTION
In Simplecov 0.16 vthey accidently excluded the MIT-LICENSE file from
their gem which is causing failures in Jenkins for us in Chef. The PR to
fix that is https://github.com/colszowka/simplecov/pull/672, but until
that gets merged and released we'll need an override.

Signed-off-by: Tim Smith <tsmith@chef.io>