### PR TITLE
Fast followups to the 2.0 release

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -4,6 +4,7 @@ slack:
 
 github:
   version_tag_format: "v{{version}}"
+  delete_branch_on_merge: true
   minor_bump_labels:
     - "Version: Bump Minor"
   release_branch:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Result | Description
 --- | ---
 Flagged | License Scout was able to determine the license for this software dependency, and it is one of the licenses you have explicitly flagged. You should either remove the dependency or [add an Exception](#dependency-exceptions).
 Missing | License Scout could not find any license files or license metadata associated with this dependency. You should contact the maintainer and/or specify a [Fallback License](#fallback-licenses).
-Unpermitted | License Scout was able to determine the license for this software dependency, but it is not one of the licenses you have explicitly allowed. You should either remove the dependency or [add an Exception](#dependency-exceptions).
+Not Allowed | License Scout was able to determine the license for this software dependency, but it is not one of the licenses you have explicitly allowed. You should either remove the dependency or [add an Exception](#dependency-exceptions).
 OK | There were no issues.
 Undetermined | License Scout found a license file but was unable to determine (with sufficient confidence) what license that file represents. License Scout was also unable to determine the license using Dependency Manager metadata. You should contact the maintainer and/or specify a [Fallback License](#fallback-licenses).
 

--- a/lib/license_scout/dependency_manager/mix.rb
+++ b/lib/license_scout/dependency_manager/mix.rb
@@ -64,7 +64,7 @@ module LicenseScout
 
           dependency = new_dependency(dep_name, dep_version, dep_path)
 
-          hex_info(dep_name)["meta"]["licenses"].each do |license|
+          Array(hex_info(dep_name).dig("meta", "licenses")).each do |license|
             dependency.add_license(license, "https://hex.pm/api/packages/#{dep_name}")
           end
 
@@ -96,6 +96,9 @@ module LicenseScout
 
       def hex_info(package_name)
         FFI_Yajl::Parser.parse(open("https://hex.pm/api/packages/#{package_name}").read)
+      rescue OpenURI::HTTPError
+        LicenseScout::Log.debug("[elixir] Unable to download hex.pm info for #{package_name}")
+        {}
       end
     end
   end

--- a/lib/license_scout/reporter.rb
+++ b/lib/license_scout/reporter.rb
@@ -61,8 +61,8 @@ module LicenseScout
 
       def reason_string
         case reason
-        when :unpermitted
-          "Unpermitted"
+        when :not_allowed
+          "Not Allowed"
         when :flagged
           "Flagged"
         when :undetermined
@@ -122,7 +122,7 @@ module LicenseScout
           @needs_fallback = true
         elsif !LicenseScout::Config.allowed_licenses.empty? && !dependency.license.is_allowed?
           unless dependency.has_exception?
-            @results[dependency.type] << Result.failure(dependency, :unpermitted)
+            @results[dependency.type] << Result.failure(dependency, :not_allowed)
             @did_fail = true
             @needs_exception = true
           else
@@ -170,10 +170,10 @@ module LicenseScout
 
       puts
       puts "Additional steps are required in order to pass Open Source license compliance:"
-      puts "  * Please add fallback licenses for the 'Missing' or 'Undetermined' dependencies"    if @needs_fallback
-      puts "         https://github.com/chef/license_scout#fallback-licenses"                     if @needs_fallback
-      puts "  * Please remove or add exceptions for the 'Flagged' or 'Unpermitted' dependencies"  if @needs_exception
-      puts "         https://github.com/chef/license_scout#dependency-exceptions"                 if @needs_exception
+      puts "  * Please add fallback licenses for the 'Missing' or 'Undetermined' dependencies"   if @needs_fallback
+      puts "         https://github.com/chef/license_scout#fallback-licenses"                    if @needs_fallback
+      puts "  * Please add exceptions for the 'Flagged' or 'Not Allowed' dependencies"           if @needs_exception
+      puts "         https://github.com/chef/license_scout#dependency-exceptions"                if @needs_exception
 
       exit 1 if @did_fail
     end


### PR DESCRIPTION
* If we cannot find a hexpm package, fail silently. We'll circle back and add better detection for which packages might be on hex.pm.
* Re-order the license result evaluation to provide more actionable results
* Use "Not Allowed" rather than "Unpermitted" to help provide clearer results

Signed-off-by: Tom Duffield <tom@chef.io>