### PR TITLE
Improve the detection of NPM licenses from the package.json

### DIFF
--- a/lib/license_scout/dependency_manager/npm.rb
+++ b/lib/license_scout/dependency_manager/npm.rb
@@ -55,11 +55,22 @@ module LicenseScout
 
           dependency = new_dependency(dep_name, dep_version, dep_path)
 
-          case pkg_info["license"]
+          license_info = pkg_info["license"] || pkg_info["licenses"]
+
+          case license_info
           when String
-            dependency.add_license(pkg_info["license"], "package.json")
+            dependency.add_license(license_info, "package.json")
           when Hash
-            dependency.add_license(pkg_info["license"]["type"], "package.json", pkg_info["license"]["url"])
+            dependency.add_license(license_info["type"], "package.json", license_info["url"])
+          when Array
+            license_info.each do |license|
+              case license
+              when String
+                dependency.add_license(license, "package.json")
+              when Hash
+                dependency.add_license(license["type"], "package.json", license["url"])
+              end
+            end
           end
 
           uniq_deps << dependency

--- a/lib/license_scout/license.rb
+++ b/lib/license_scout/license.rb
@@ -110,6 +110,16 @@ module LicenseScout
         rescue OpenURI::HTTPError
           LicenseScout::Log.warn("[license] Unable to download license for #{license_id} from #{new_url}")
           nil
+        rescue RuntimeError => e
+          if e.message =~ /redirection forbidden/
+            m = /redirection forbidden:\s+(.+)\s+->\s+(.+)/.match(e.message)
+            new_https_url = m[2].gsub("http://", "https://")
+
+            LicenseScout::Log.debug("[license] Retrying download of #{license_id} from #{new_https_url}")
+            license_content(license_id, new_https_url)
+          else
+            raise e
+          end
         end
       end
     end

--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -30,20 +30,20 @@ Gem::Specification.new do |spec|
   spec.description   = "Discovers license files of a project's dependencies."
   spec.homepage      = "https://github.com/chef/license_scout"
 
-  spec.files         = Dir["LICENSE", "README.md", "{bin,native_parsers,lib}/**/*"]
+  spec.files         = Dir["LICENSE", "README.md", "{bin,lib}/**/*"]
   spec.bindir        = "bin"
   spec.executables   = %w{license_scout}
   spec.require_paths = %w{lib}
 
-  spec.add_dependency "ffi-yajl",        "~> 2.2"
-  spec.add_dependency "mixlib-shellout", "~> 2.2"
-  spec.add_dependency "toml-rb",         "~> 1.0"
-  spec.add_dependency "licensee",        "~> 9.8"
-  spec.add_dependency "mixlib-config",   "~> 2.2"
-  spec.add_dependency "mixlib-cli"
-  spec.add_dependency "mixlib-log"
-  spec.add_dependency "terminal-table"
-  spec.add_dependency "fuzzy_match"
+  spec.add_runtime_dependency "ffi-yajl",        "~> 2.2"
+  spec.add_runtime_dependency "mixlib-shellout", "~> 2.2"
+  spec.add_runtime_dependency "toml-rb",         "~> 1.0"
+  spec.add_runtime_dependency "licensee",        "~> 9.8"
+  spec.add_runtime_dependency "mixlib-config",   "~> 2.2"
+  spec.add_runtime_dependency "mixlib-cli"
+  spec.add_runtime_dependency "mixlib-log"
+  spec.add_runtime_dependency "terminal-table"
+  spec.add_runtime_dependency "fuzzy_match"
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/dedups_dependencies_only_if_they_are_the_same_version.yml
+++ b/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/dedups_dependencies_only_if_they_are_the_same_version.yml
@@ -2,6 +2,430 @@
 http_interactions:
 - request:
     method: get
+    uri: https://raw.github.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:39 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18642-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - b0fb298a6427e3d1ca01949a532fea889403b313
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:39 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"8c84e398668b79fbb7243523cbabe02be58029ee"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6A36:30FB:304F4:31F80:5AD6766D
+      Content-Length:
+      - '672'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:39 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18647-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '3'
+      X-Timer:
+      - S1524004480.585068,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 38db4ef3e9f9dd2bfafc71afae3386409a941ab8
+      Expires:
+      - Tue, 17 Apr 2018 22:39:39 GMT
+      Source-Age:
+      - '18'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:39 GMT
+- request:
+    method: get
+    uri: http://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:39 GMT
+- request:
+    method: get
+    uri: https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:27 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+      X-Runtime:
+      - '0.043964'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.048717'
+      Age:
+      - '13'
+      Content-Length:
+      - '130'
+      X-Github-Request-Id:
+      - CC1C:605B:85301A:1132429:5AD6767F
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:39 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"6dc3e82d3c2e9b7a4e005075c965de4e32c72eb7"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 4F6C:1722:38D63:3C025:5AD6766D
+      Content-Length:
+      - '865'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:40 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18622-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004480.089234,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 45727ff559110272d1edccd75a7fcf7ed5fa5f1e
+      Expires:
+      - Tue, 17 Apr 2018 22:39:40 GMT
+      Source-Age:
+      - '18'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        Copyright (c) 2012-2016, Eran Hammer and Project contributors
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * The names of any contributors may not be used to endorse or promote
+              products derived from this software without specific prior written
+              permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                          *   *   *
+
+        The complete list of contributors can be found at: https://github.com/hueniverse/sntp/graphs/contributors
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:40 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/dominictarr/config-chain/master/LICENCE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"171dd970053ce33587ab3960a61b9cb56a9313d6"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - DC0E:72AF:5298:5A15:5AD6766E
+      Content-Length:
+      - '646'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:40 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18625-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004480.351015,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - d2630108693d3d7053f4dd999d42ff7d42546b5c
+      Expires:
+      - Tue, 17 Apr 2018 22:39:40 GMT
+      Source-Age:
+      - '18'
+    body:
+      encoding: ASCII-8BIT
+      string: "Copyright (c) 2011 Dominic Tarr\n\nPermission is hereby granted, free
+        of charge, \nto any person obtaining a copy of this software and \nassociated
+        documentation files (the \"Software\"), to \ndeal in the Software without
+        restriction, including \nwithout limitation the rights to use, copy, modify,
+        \nmerge, publish, distribute, sublicense, and/or sell \ncopies of the Software,
+        and to permit persons to whom \nthe Software is furnished to do so, \nsubject
+        to the following conditions:\n\nThe above copyright notice and this permission
+        notice \nshall be included in all copies or substantial portions of the Software.\n\nTHE
+        SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, \nEXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \nOF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. \nIN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR \nANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, \nTORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE \nSOFTWARE OR THE USE OR OTHER DEALINGS
+        IN THE SOFTWARE."
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:40 GMT
+- request:
+    method: get
     uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
     body:
       encoding: US-ASCII
@@ -37,35 +461,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - D5D8:2D30:551C1:5A111:5ACF788E
+      - 23CE:1727:1ABBB:1C21E:5AD6766D
       Content-Length:
       - '680'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:38 GMT
+      - Tue, 17 Apr 2018 22:34:40 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18647-DFW
+      - cache-dfw18644-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Timer:
-      - S1523546259.746572,VS0,VE1
+      - S1524004481.661082,VS0,VE0
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 70ccf2d9344eb1e8b64e47ffa89e2aaf514915ee
+      - '09c3479e8cb428e2596fd9ef4e027803b92c5337'
       Expires:
-      - Thu, 12 Apr 2018 15:22:38 GMT
+      - Tue, 17 Apr 2018 22:39:40 GMT
       Source-Age:
-      - '3'
+      - '18'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -89,7 +513,7 @@ http_interactions:
         # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         # THE SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:38 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:40 GMT
 - request:
     method: get
     uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -116,7 +540,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:39 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:40 GMT
 - request:
     method: get
     uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -138,7 +562,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 12 Apr 2018 15:17:36 GMT
+      - Tue, 17 Apr 2018 22:34:41 GMT
       Content-Type:
       - text/html; charset=utf-8
       Status:
@@ -156,7 +580,7 @@ http_interactions:
       Location:
       - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
       X-Runtime:
-      - '0.074084'
+      - '0.060182'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Frame-Options:
@@ -177,20 +601,20 @@ http_interactions:
         frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
         collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
-        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+        style-src ''unsafe-inline'' assets-cdn.github.com'
       X-Runtime-Rack:
-      - '0.082005'
+      - '0.067719'
       Age:
-      - '4'
+      - '0'
       Content-Length:
       - '136'
       X-Github-Request-Id:
-      - DAEA:4382:605518:B8FC8C:5ACF7893
+      - CC21:605E:FB18E1:1E96B34:5AD67680
     body:
       encoding: UTF-8
       string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:40 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:41 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
@@ -228,35 +652,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - BB04:0496:28209:2A70A:5ACF788F
+      - EFFE:0950:4CBC0:4FC03:5AD6766E
       Content-Length:
       - '490'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:40 GMT
+      - Tue, 17 Apr 2018 22:34:41 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18646-DFW
+      - cache-dfw18635-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
       - '1'
       X-Timer:
-      - S1523546260.229444,VS0,VE60
+      - S1524004481.170408,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - f0049ff2cd03f656d82c7565778f6635ecdb43ea
+      - 8facaba9a6421085a69d2fb77b91985a2399b53d
       Expires:
-      - Thu, 12 Apr 2018 15:22:40 GMT
+      - Tue, 17 Apr 2018 22:39:41 GMT
       Source-Age:
-      - '4'
+      - '18'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -276,5 +700,144 @@ http_interactions:
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:40 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:41 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:41 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18633-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 197aaf7b1440be22965bcb8fbdf7d6d139f5508c
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:41 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"d3f46f7e145990dad5954d78c5da9a2c2bdcbe36"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6424:5053:34333:36FB6:5AD6766F
+      Content-Length:
+      - '666'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:41 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18640-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004482.554054,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - a67fc1ef4f72b93bb89a53eb59bac9ed9623e5c5
+      Expires:
+      - Tue, 17 Apr 2018 22:39:41 GMT
+      Source-Age:
+      - '18'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:41 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_all_transitive_dependencies.yml
+++ b/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_all_transitive_dependencies.yml
@@ -2,7 +2,54 @@
 http_interactions:
 - request:
     method: get
-    uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
+    uri: https://raw.github.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:34 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18628-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 25e82d6dff0a481fd378375becbeb37032dc6b48
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:34 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
     body:
       encoding: US-ASCII
       string: ''
@@ -29,7 +76,7 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Etag:
-      - '"a4d6a95fd3b64ebbcbbfad981808c188e58d73a9"'
+      - '"8c84e398668b79fbb7243523cbabe02be58029ee"'
       Content-Type:
       - text/plain; charset=utf-8
       Cache-Control:
@@ -37,13 +84,206 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - D5D8:2D30:551C1:5A111:5ACF788E
+      - 6A36:30FB:304F4:31F80:5AD6766D
       Content-Length:
-      - '680'
+      - '672'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:44 GMT
+      - Tue, 17 Apr 2018 22:34:34 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18647-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Timer:
+      - S1524004475.525656,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 110a3f44bb3f800168b7a8c194faba9d5fb4b493
+      Expires:
+      - Tue, 17 Apr 2018 22:39:34 GMT
+      Source-Age:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:34 GMT
+- request:
+    method: get
+    uri: http://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:34 GMT
+- request:
+    method: get
+    uri: https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:32 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+      X-Runtime:
+      - '0.057396'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.064385'
+      Age:
+      - '2'
+      Content-Length:
+      - '130'
+      X-Github-Request-Id:
+      - CC03:605D:D7132D:1AAEC41:5AD6767A
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:34 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"6dc3e82d3c2e9b7a4e005075c965de4e32c72eb7"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 4F6C:1722:38D63:3C025:5AD6766D
+      Content-Length:
+      - '865'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:35 GMT
       Via:
       - 1.1 varnish
       Connection:
@@ -53,147 +293,55 @@ http_interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Timer:
-      - S1523546264.169708,VS0,VE0
+      - S1524004475.019615,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - c10bb729648bace46461f6f6fcf1b622520949d9
+      - 4a620a389d50c54b7825adac870741a808160c5b
       Expires:
-      - Thu, 12 Apr 2018 15:22:44 GMT
+      - Tue, 17 Apr 2018 22:39:35 GMT
       Source-Age:
-      - '9'
+      - '13'
     body:
       encoding: ASCII-8BIT
       string: |
-        # MIT LICENSED Copyright (c) 2013 Arnout Kazemier (http://3rd-Eden.com)
-        #
-        # Permission is hereby granted, free of charge, to any person obtaining a copy
-        # of this software and associated documentation files (the "Software"), to deal
-        # in the Software without restriction, including without limitation the rights
-        # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-        # copies of the Software, and to permit persons to whom the Software is
-        # furnished to do so, subject to the following conditions:
-        #
-        # The above copyright notice and this permission notice shall be included in
-        # all copies or substantial portions of the Software.
-        #
-        # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-        # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-        # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-        # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-        # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-        # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-        # THE SOFTWARE.
+        Copyright (c) 2012-2016, Eran Hammer and Project contributors
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * The names of any contributors may not be used to endorse or promote
+              products derived from this software without specific prior written
+              permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                          *   *   *
+
+        The complete list of contributors can be found at: https://github.com/hueniverse/sntp/graphs/contributors
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:44 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:35 GMT
 - request:
     method: get
-    uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 301
-      message: Moved Permanently
-    headers:
-      Content-Length:
-      - '0'
-      Location:
-      - https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:44 GMT
-- request:
-    method: get
-    uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 302
-      message: Found
-    headers:
-      Server:
-      - GitHub.com
-      Date:
-      - Thu, 12 Apr 2018 15:17:37 GMT
-      Content-Type:
-      - text/html; charset=utf-8
-      Status:
-      - 302 Found
-      Cache-Control:
-      - no-cache
-      Vary:
-      - X-PJAX
-      X-Ratelimit-Limit:
-      - '100'
-      X-Ratelimit-Remaining:
-      - '100'
-      Access-Control-Allow-Origin:
-      - https://render.githubusercontent.com
-      Location:
-      - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
-      X-Runtime:
-      - '0.044812'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      X-Frame-Options:
-      - deny
-      X-Content-Type-Options:
-      - nosniff
-      X-Xss-Protection:
-      - 1; mode=block
-      Expect-Ct:
-      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
-      Content-Security-Policy:
-      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
-        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
-        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
-        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
-        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
-        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
-        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
-        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
-        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
-        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
-      X-Runtime-Rack:
-      - '0.050032'
-      Age:
-      - '7'
-      Content-Length:
-      - '136'
-      X-Github-Request-Id:
-      - DAF6:4385:CFA613:174E8D5:5ACF7898
-    body:
-      encoding: UTF-8
-      string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
-    http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:44 GMT
-- request:
-    method: get
-    uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
+    uri: https://raw.githubusercontent.com/dominictarr/config-chain/master/LICENCE
     body:
       encoding: US-ASCII
       string: ''
@@ -220,7 +368,7 @@ http_interactions:
       X-Xss-Protection:
       - 1; mode=block
       Etag:
-      - '"19129e315fe593965a2fdd50ec0d1253bcbd2ece"'
+      - '"171dd970053ce33587ab3960a61b9cb56a9313d6"'
       Content-Type:
       - text/plain; charset=utf-8
       Cache-Control:
@@ -228,55 +376,54 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - BB04:0496:28209:2A70A:5ACF788F
+      - DC0E:72AF:5298:5A15:5AD6766E
       Content-Length:
-      - '490'
+      - '646'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:44 GMT
+      - Tue, 17 Apr 2018 22:34:35 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18637-DFW
+      - cache-dfw18623-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Timer:
-      - S1523546265.935342,VS0,VE1
+      - S1524004475.284794,VS0,VE0
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 56e0fe664c8ee7224d2c8acd57c52a5be1f4502a
+      - 9c6e4e36533a8e903bd6cc836c0019b6465a1a44
       Expires:
-      - Thu, 12 Apr 2018 15:22:44 GMT
+      - Tue, 17 Apr 2018 22:39:35 GMT
       Source-Age:
-      - '8'
+      - '12'
     body:
       encoding: ASCII-8BIT
-      string: |
-        The ISC License
-
-        Copyright (c) Isaac Z. Schlueter and Contributors
-
-        Permission to use, copy, modify, and/or distribute this software for any
-        purpose with or without fee is hereby granted, provided that the above
-        copyright notice and this permission notice appear in all copies.
-
-        THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-        WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-        MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-        ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-        WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-        ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-        IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+      string: "Copyright (c) 2011 Dominic Tarr\n\nPermission is hereby granted, free
+        of charge, \nto any person obtaining a copy of this software and \nassociated
+        documentation files (the \"Software\"), to \ndeal in the Software without
+        restriction, including \nwithout limitation the rights to use, copy, modify,
+        \nmerge, publish, distribute, sublicense, and/or sell \ncopies of the Software,
+        and to permit persons to whom \nthe Software is furnished to do so, \nsubject
+        to the following conditions:\n\nThe above copyright notice and this permission
+        notice \nshall be included in all copies or substantial portions of the Software.\n\nTHE
+        SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, \nEXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \nOF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. \nIN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR \nANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, \nTORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE \nSOFTWARE OR THE USE OR OTHER DEALINGS
+        IN THE SOFTWARE."
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:44 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:35 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
@@ -314,35 +461,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - D5D8:2D30:551C1:5A111:5ACF788E
+      - 23CE:1727:1ABBB:1C21E:5AD6766D
       Content-Length:
       - '680'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:45 GMT
+      - Tue, 17 Apr 2018 22:34:35 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18635-DFW
+      - cache-dfw18639-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
       - '1'
       X-Timer:
-      - S1523546266.746240,VS0,VE1
+      - S1524004476.607707,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - ec37ddbba023bc69a82ee5790adff5e2f8fca451
+      - 6f7fbb532eda9b78e72a8e2d0681b45328a24d5a
       Expires:
-      - Thu, 12 Apr 2018 15:22:45 GMT
+      - Tue, 17 Apr 2018 22:39:35 GMT
       Source-Age:
-      - '10'
+      - '13'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -366,7 +513,7 @@ http_interactions:
         # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         # THE SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:45 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:35 GMT
 - request:
     method: get
     uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -393,7 +540,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:45 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:35 GMT
 - request:
     method: get
     uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -415,7 +562,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 12 Apr 2018 15:17:36 GMT
+      - Tue, 17 Apr 2018 22:34:23 GMT
       Content-Type:
       - text/html; charset=utf-8
       Status:
@@ -433,7 +580,7 @@ http_interactions:
       Location:
       - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
       X-Runtime:
-      - '0.074084'
+      - '0.058411'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Frame-Options:
@@ -454,20 +601,20 @@ http_interactions:
         frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
         collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
-        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+        style-src ''unsafe-inline'' assets-cdn.github.com'
       X-Runtime-Rack:
-      - '0.082005'
+      - '0.063980'
       Age:
-      - '10'
+      - '13'
       Content-Length:
       - '136'
       X-Github-Request-Id:
-      - DAFA:4382:6058B3:B90498:5ACF7899
+      - CC08:605D:D71387:1AAECEF:5AD6767B
     body:
       encoding: UTF-8
       string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:46 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:35 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
@@ -505,35 +652,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - BB04:0496:28209:2A70A:5ACF788F
+      - EFFE:0950:4CBC0:4FC03:5AD6766E
       Content-Length:
       - '490'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:46 GMT
+      - Tue, 17 Apr 2018 22:34:36 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18643-DFW
+      - cache-dfw18629-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
       - '1'
       X-Timer:
-      - S1523546266.216132,VS0,VE1
+      - S1524004476.087720,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 60a9c335d09588fe7f4e10f7c81a50071f5e1e5c
+      - ed33f4fa9a48c7c362ae15c551c739ff197fc494
       Expires:
-      - Thu, 12 Apr 2018 15:22:46 GMT
+      - Tue, 17 Apr 2018 22:39:36 GMT
       Source-Age:
-      - '10'
+      - '13'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -553,5 +700,984 @@ http_interactions:
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:46 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:36 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:36 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18650-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 9a491df504f37937415376f8de36a0f8528a8819
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:36 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"d3f46f7e145990dad5954d78c5da9a2c2bdcbe36"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6424:5053:34333:36FB6:5AD6766F
+      Content-Length:
+      - '666'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:36 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18649-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004477.553228,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - c50747158e2571210d2865016a81e84ebdae7731
+      Expires:
+      - Tue, 17 Apr 2018 22:39:36 GMT
+      Source-Age:
+      - '13'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:36 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:36 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18624-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - a3769a25694eaf17521a6f4e5981e0dd44486247
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:36 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"8c84e398668b79fbb7243523cbabe02be58029ee"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6A36:30FB:304F4:31F80:5AD6766D
+      Content-Length:
+      - '672'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:37 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18627-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004477.075496,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - e46a180eea5411650a8309c237abc6890df537ac
+      Expires:
+      - Tue, 17 Apr 2018 22:39:37 GMT
+      Source-Age:
+      - '16'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:37 GMT
+- request:
+    method: get
+    uri: http://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:37 GMT
+- request:
+    method: get
+    uri: https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:27 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+      X-Runtime:
+      - '0.043964'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.048717'
+      Age:
+      - '10'
+      Content-Length:
+      - '130'
+      X-Github-Request-Id:
+      - CC0F:605C:AA584B:15C77EC:5AD6767D
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:37 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"6dc3e82d3c2e9b7a4e005075c965de4e32c72eb7"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 4F6C:1722:38D63:3C025:5AD6766D
+      Content-Length:
+      - '865'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:37 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18650-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004478.591356,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - bcef0326fb56bad21b4be612d71158adff32c38a
+      Expires:
+      - Tue, 17 Apr 2018 22:39:37 GMT
+      Source-Age:
+      - '15'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        Copyright (c) 2012-2016, Eran Hammer and Project contributors
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * The names of any contributors may not be used to endorse or promote
+              products derived from this software without specific prior written
+              permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                          *   *   *
+
+        The complete list of contributors can be found at: https://github.com/hueniverse/sntp/graphs/contributors
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:37 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/dominictarr/config-chain/master/LICENCE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"171dd970053ce33587ab3960a61b9cb56a9313d6"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - DC0E:72AF:5298:5A15:5AD6766E
+      Content-Length:
+      - '646'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:37 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18644-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004478.850727,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 1f83c9a5800402f1e011b07f13a87fb9bddb7751
+      Expires:
+      - Tue, 17 Apr 2018 22:39:37 GMT
+      Source-Age:
+      - '15'
+    body:
+      encoding: ASCII-8BIT
+      string: "Copyright (c) 2011 Dominic Tarr\n\nPermission is hereby granted, free
+        of charge, \nto any person obtaining a copy of this software and \nassociated
+        documentation files (the \"Software\"), to \ndeal in the Software without
+        restriction, including \nwithout limitation the rights to use, copy, modify,
+        \nmerge, publish, distribute, sublicense, and/or sell \ncopies of the Software,
+        and to permit persons to whom \nthe Software is furnished to do so, \nsubject
+        to the following conditions:\n\nThe above copyright notice and this permission
+        notice \nshall be included in all copies or substantial portions of the Software.\n\nTHE
+        SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, \nEXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \nOF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. \nIN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR \nANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, \nTORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE \nSOFTWARE OR THE USE OR OTHER DEALINGS
+        IN THE SOFTWARE."
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:37 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"a4d6a95fd3b64ebbcbbfad981808c188e58d73a9"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 23CE:1727:1ABBB:1C21E:5AD6766D
+      Content-Length:
+      - '680'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:38 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18646-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004478.163727,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - d709ab630818ad3e1ac240e580fa665fe68c39ea
+      Expires:
+      - Tue, 17 Apr 2018 22:39:38 GMT
+      Source-Age:
+      - '15'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        # MIT LICENSED Copyright (c) 2013 Arnout Kazemier (http://3rd-Eden.com)
+        #
+        # Permission is hereby granted, free of charge, to any person obtaining a copy
+        # of this software and associated documentation files (the "Software"), to deal
+        # in the Software without restriction, including without limitation the rights
+        # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        # copies of the Software, and to permit persons to whom the Software is
+        # furnished to do so, subject to the following conditions:
+        #
+        # The above copyright notice and this permission notice shall be included in
+        # all copies or substantial portions of the Software.
+        #
+        # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        # THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:38 GMT
+- request:
+    method: get
+    uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:38 GMT
+- request:
+    method: get
+    uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:28 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
+      X-Runtime:
+      - '0.059190'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.066306'
+      Age:
+      - '10'
+      Content-Length:
+      - '136'
+      X-Github-Request-Id:
+      - CC15:605D:D714CC:1AAEF67:5AD6767E
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:38 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"19129e315fe593965a2fdd50ec0d1253bcbd2ece"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - EFFE:0950:4CBC0:4FC03:5AD6766E
+      Content-Length:
+      - '490'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:38 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18643-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Timer:
+      - S1524004479.629358,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - d60cbc8d30ab69c70b1aa2983643d7827f2a1851
+      Expires:
+      - Tue, 17 Apr 2018 22:39:38 GMT
+      Source-Age:
+      - '15'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The ISC License
+
+        Copyright (c) Isaac Z. Schlueter and Contributors
+
+        Permission to use, copy, modify, and/or distribute this software for any
+        purpose with or without fee is hereby granted, provided that the above
+        copyright notice and this permission notice appear in all copies.
+
+        THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+        WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+        MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+        ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+        WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+        ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+        IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:38 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:38 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '2'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18625-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - f0fb438421e4afd07e0e54147e5823b1c03ac75c
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:38 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"d3f46f7e145990dad5954d78c5da9a2c2bdcbe36"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6424:5053:34333:36FB6:5AD6766F
+      Content-Length:
+      - '666'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:38 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18649-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Timer:
+      - S1524004479.980009,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 938324e9fa1f4f7970d71d51206aea8bda4afe12
+      Expires:
+      - Tue, 17 Apr 2018 22:39:38 GMT
+      Source-Age:
+      - '15'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:38 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_dependencies_with_license_files_and_license_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_dependencies_with_license_files_and_license_metadata.yml
@@ -2,6 +2,430 @@
 http_interactions:
 - request:
     method: get
+    uri: https://raw.github.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:24 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18637-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 2e0a85546cff301b5dab61e0b62d72f880f6a999
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:24 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"8c84e398668b79fbb7243523cbabe02be58029ee"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6A36:30FB:304F4:31F80:5AD6766D
+      Content-Length:
+      - '672'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:24 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18623-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004465.553918,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 886725aa298bb39a643ec2e458f54c49077ca009
+      Expires:
+      - Tue, 17 Apr 2018 22:39:24 GMT
+      Source-Age:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:24 GMT
+- request:
+    method: get
+    uri: http://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:24 GMT
+- request:
+    method: get
+    uri: https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:21 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+      X-Runtime:
+      - '0.041823'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.047208'
+      Age:
+      - '3'
+      Content-Length:
+      - '130'
+      X-Github-Request-Id:
+      - CBD2:605D:D70DF1:1AAE16D:5AD67670
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:24 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"6dc3e82d3c2e9b7a4e005075c965de4e32c72eb7"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 4F6C:1722:38D63:3C025:5AD6766D
+      Content-Length:
+      - '865'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:25 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18638-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004465.049371,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 1a6c5ae277dcccdfa83a35a1b898fde4a993d27d
+      Expires:
+      - Tue, 17 Apr 2018 22:39:25 GMT
+      Source-Age:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        Copyright (c) 2012-2016, Eran Hammer and Project contributors
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * The names of any contributors may not be used to endorse or promote
+              products derived from this software without specific prior written
+              permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                          *   *   *
+
+        The complete list of contributors can be found at: https://github.com/hueniverse/sntp/graphs/contributors
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:25 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/dominictarr/config-chain/master/LICENCE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"171dd970053ce33587ab3960a61b9cb56a9313d6"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - DC0E:72AF:5298:5A15:5AD6766E
+      Content-Length:
+      - '646'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:25 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18646-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004465.313614,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 0b98bc8f96f17afb3b07e2ecae5a0a332e832ec0
+      Expires:
+      - Tue, 17 Apr 2018 22:39:25 GMT
+      Source-Age:
+      - '3'
+    body:
+      encoding: ASCII-8BIT
+      string: "Copyright (c) 2011 Dominic Tarr\n\nPermission is hereby granted, free
+        of charge, \nto any person obtaining a copy of this software and \nassociated
+        documentation files (the \"Software\"), to \ndeal in the Software without
+        restriction, including \nwithout limitation the rights to use, copy, modify,
+        \nmerge, publish, distribute, sublicense, and/or sell \ncopies of the Software,
+        and to permit persons to whom \nthe Software is furnished to do so, \nsubject
+        to the following conditions:\n\nThe above copyright notice and this permission
+        notice \nshall be included in all copies or substantial portions of the Software.\n\nTHE
+        SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, \nEXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \nOF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. \nIN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR \nANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, \nTORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE \nSOFTWARE OR THE USE OR OTHER DEALINGS
+        IN THE SOFTWARE."
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:25 GMT
+- request:
+    method: get
     uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
     body:
       encoding: US-ASCII
@@ -37,35 +461,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - D5D8:2D30:551C1:5A111:5ACF788E
+      - 23CE:1727:1ABBB:1C21E:5AD6766D
       Content-Length:
       - '680'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:47 GMT
+      - Tue, 17 Apr 2018 22:34:25 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18633-DFW
+      - cache-dfw18644-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
       - '1'
       X-Timer:
-      - S1523546267.024172,VS0,VE1
+      - S1524004466.641123,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 10877d3bf54d0226466148fe3cccbce6433745d8
+      - 4b52d73ae18e986d649ffef1deda017a30014ced
       Expires:
-      - Thu, 12 Apr 2018 15:22:47 GMT
+      - Tue, 17 Apr 2018 22:39:25 GMT
       Source-Age:
-      - '11'
+      - '3'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -89,7 +513,7 @@ http_interactions:
         # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         # THE SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:47 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:25 GMT
 - request:
     method: get
     uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -116,7 +540,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:47 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:25 GMT
 - request:
     method: get
     uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -138,7 +562,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 12 Apr 2018 15:17:37 GMT
+      - Tue, 17 Apr 2018 22:34:23 GMT
       Content-Type:
       - text/html; charset=utf-8
       Status:
@@ -156,7 +580,7 @@ http_interactions:
       Location:
       - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
       X-Runtime:
-      - '0.044812'
+      - '0.058411'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Frame-Options:
@@ -177,20 +601,20 @@ http_interactions:
         frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
         collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
-        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+        style-src ''unsafe-inline'' assets-cdn.github.com'
       X-Runtime-Rack:
-      - '0.050032'
+      - '0.063980'
       Age:
-      - '10'
+      - '3'
       Content-Length:
       - '136'
       X-Github-Request-Id:
-      - DAFE:4382:60594E:B905C5:5ACF789B
+      - CBD7:605B:852BEB:1131B71:5AD67671
     body:
       encoding: UTF-8
       string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:47 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:25 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
@@ -228,35 +652,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - BB04:0496:28209:2A70A:5ACF788F
+      - EFFE:0950:4CBC0:4FC03:5AD6766E
       Content-Length:
       - '490'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:47 GMT
+      - Tue, 17 Apr 2018 22:34:26 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18647-DFW
+      - cache-dfw18643-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
       - '1'
       X-Timer:
-      - S1523546268.661445,VS0,VE1
+      - S1524004466.072453,VS0,VE0
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 3bc4a2e6675ceeeb51172eec4068f249cdb89130
+      - cafd6c3fc8e8d96a3207e2c24b587ad20cd48dfd
       Expires:
-      - Thu, 12 Apr 2018 15:22:47 GMT
+      - Tue, 17 Apr 2018 22:39:26 GMT
       Source-Age:
-      - '11'
+      - '3'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -276,5 +700,144 @@ http_interactions:
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:47 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:26 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:26 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '2'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18640-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 6f5282db979e351b1c44487b7e9a94bead48102c
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:26 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"d3f46f7e145990dad5954d78c5da9a2c2bdcbe36"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6424:5053:34333:36FB6:5AD6766F
+      Content-Length:
+      - '666'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:26 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18624-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004466.422231,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 53a59d68cf9ea2492a6b20af4a7d5b888ae105ff
+      Expires:
+      - Tue, 17 Apr 2018 22:39:26 GMT
+      Source-Age:
+      - '2'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:26 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_dependencies_with_license_files_but_no_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_dependencies_with_license_files_but_no_metadata.yml
@@ -2,6 +2,430 @@
 http_interactions:
 - request:
     method: get
+    uri: https://raw.github.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:31 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '5'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18629-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - a8a47d11d15e3aeae0381a79ff2101da4905c399
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:31 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"8c84e398668b79fbb7243523cbabe02be58029ee"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6A36:30FB:304F4:31F80:5AD6766D
+      Content-Length:
+      - '672'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:31 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18647-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004472.973212,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 96d4660d1e7d8a69f824730c3658c84308b18124
+      Expires:
+      - Tue, 17 Apr 2018 22:39:31 GMT
+      Source-Age:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:31 GMT
+- request:
+    method: get
+    uri: http://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:32 GMT
+- request:
+    method: get
+    uri: https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:32 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+      X-Runtime:
+      - '0.057396'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.064385'
+      Age:
+      - '0'
+      Content-Length:
+      - '130'
+      X-Github-Request-Id:
+      - CBF7:605D:D711E7:1AAE9B2:5AD67678
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:32 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"6dc3e82d3c2e9b7a4e005075c965de4e32c72eb7"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 4F6C:1722:38D63:3C025:5AD6766D
+      Content-Length:
+      - '865'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:32 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18623-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004473.549087,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 779d571d0970538a325b8822034710403f22e775
+      Expires:
+      - Tue, 17 Apr 2018 22:39:32 GMT
+      Source-Age:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        Copyright (c) 2012-2016, Eran Hammer and Project contributors
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * The names of any contributors may not be used to endorse or promote
+              products derived from this software without specific prior written
+              permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                          *   *   *
+
+        The complete list of contributors can be found at: https://github.com/hueniverse/sntp/graphs/contributors
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:32 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/dominictarr/config-chain/master/LICENCE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"171dd970053ce33587ab3960a61b9cb56a9313d6"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - DC0E:72AF:5298:5A15:5AD6766E
+      Content-Length:
+      - '646'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:32 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18626-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004473.816054,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 15bd86e43974d0909598ffec784a92527b33129c
+      Expires:
+      - Tue, 17 Apr 2018 22:39:32 GMT
+      Source-Age:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: "Copyright (c) 2011 Dominic Tarr\n\nPermission is hereby granted, free
+        of charge, \nto any person obtaining a copy of this software and \nassociated
+        documentation files (the \"Software\"), to \ndeal in the Software without
+        restriction, including \nwithout limitation the rights to use, copy, modify,
+        \nmerge, publish, distribute, sublicense, and/or sell \ncopies of the Software,
+        and to permit persons to whom \nthe Software is furnished to do so, \nsubject
+        to the following conditions:\n\nThe above copyright notice and this permission
+        notice \nshall be included in all copies or substantial portions of the Software.\n\nTHE
+        SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, \nEXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \nOF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. \nIN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR \nANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, \nTORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE \nSOFTWARE OR THE USE OR OTHER DEALINGS
+        IN THE SOFTWARE."
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:32 GMT
+- request:
+    method: get
     uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
     body:
       encoding: US-ASCII
@@ -37,35 +461,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - D5D8:2D30:551C1:5A111:5ACF788E
+      - 23CE:1727:1ABBB:1C21E:5AD6766D
       Content-Length:
       - '680'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:42 GMT
+      - Tue, 17 Apr 2018 22:34:33 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18626-DFW
+      - cache-dfw18620-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Timer:
-      - S1523546263.601154,VS0,VE1
+      - S1524004473.127574,VS0,VE0
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 0d3e85a915ce385dcb101bb1eb7869eb8435399e
+      - 5b986ce67af9f4be0e3039b7fa47ee16b115a976
       Expires:
-      - Thu, 12 Apr 2018 15:22:42 GMT
+      - Tue, 17 Apr 2018 22:39:33 GMT
       Source-Age:
-      - '7'
+      - '10'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -89,7 +513,7 @@ http_interactions:
         # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         # THE SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:42 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:33 GMT
 - request:
     method: get
     uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -116,7 +540,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:42 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:33 GMT
 - request:
     method: get
     uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -138,7 +562,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 12 Apr 2018 15:17:43 GMT
+      - Tue, 17 Apr 2018 22:34:28 GMT
       Content-Type:
       - text/html; charset=utf-8
       Status:
@@ -156,7 +580,7 @@ http_interactions:
       Location:
       - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
       X-Runtime:
-      - '0.070108'
+      - '0.059190'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Frame-Options:
@@ -177,20 +601,20 @@ http_interactions:
         frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
         collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
-        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+        style-src ''unsafe-inline'' assets-cdn.github.com'
       X-Runtime-Rack:
-      - '0.077969'
+      - '0.066306'
       Age:
-      - '0'
-      Transfer-Encoding:
-      - chunked
+      - '5'
+      Content-Length:
+      - '136'
       X-Github-Request-Id:
-      - DAF2:4385:CFA514:174E6E3:5ACF7896
+      - CBFC:605E:FB1400:1E9622F:5AD67679
     body:
       encoding: UTF-8
       string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:43 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:33 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
@@ -228,35 +652,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - BB04:0496:28209:2A70A:5ACF788F
+      - EFFE:0950:4CBC0:4FC03:5AD6766E
       Content-Length:
       - '490'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:43 GMT
+      - Tue, 17 Apr 2018 22:34:33 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18630-DFW
+      - cache-dfw18628-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Timer:
-      - S1523546263.308386,VS0,VE0
+      - S1524004474.592675,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 3471a899d0589b4d421b88b7de5d11fb00082768
+      - 05b5bcedba97ee36ff1472a90f20d0f776a72b40
       Expires:
-      - Thu, 12 Apr 2018 15:22:43 GMT
+      - Tue, 17 Apr 2018 22:39:33 GMT
       Source-Age:
-      - '6'
+      - '10'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -276,5 +700,144 @@ http_interactions:
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:43 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:33 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:33 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '5'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18651-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 4b09f168b148b1fad03acfaae6b011366a24a32d
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:33 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"d3f46f7e145990dad5954d78c5da9a2c2bdcbe36"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6424:5053:34333:36FB6:5AD6766F
+      Content-Length:
+      - '666'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:33 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18650-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004474.967393,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - a5248315cdb7b016c6440a24a2d8e891a95b8f61
+      Expires:
+      - Tue, 17 Apr 2018 22:39:33 GMT
+      Source-Age:
+      - '10'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:33 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_dependencies_with_license_metadata_but_no_license_files.yml
+++ b/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_dependencies_with_license_metadata_but_no_license_files.yml
@@ -2,6 +2,430 @@
 http_interactions:
 - request:
     method: get
+    uri: https://raw.github.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:29 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '3'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18647-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - e0c089d7c9cf83c29ee97e24a2d231a1683cf0c7
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:29 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"8c84e398668b79fbb7243523cbabe02be58029ee"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6A36:30FB:304F4:31F80:5AD6766D
+      Content-Length:
+      - '672'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:29 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18622-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004470.565024,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - b6aa325abb82ab40fbfcbd35e6816f72f9a383a2
+      Expires:
+      - Tue, 17 Apr 2018 22:39:29 GMT
+      Source-Age:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:29 GMT
+- request:
+    method: get
+    uri: http://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:29 GMT
+- request:
+    method: get
+    uri: https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:21 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+      X-Runtime:
+      - '0.041823'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.047208'
+      Age:
+      - '8'
+      Content-Length:
+      - '130'
+      X-Github-Request-Id:
+      - CBEA:605C:AA5552:15C7205:5AD67675
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:29 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"6dc3e82d3c2e9b7a4e005075c965de4e32c72eb7"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 4F6C:1722:38D63:3C025:5AD6766D
+      Content-Length:
+      - '865'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:30 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18643-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004470.076750,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - d173561ec0c7e99d9e5af320cb47d0dba958d56c
+      Expires:
+      - Tue, 17 Apr 2018 22:39:30 GMT
+      Source-Age:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        Copyright (c) 2012-2016, Eran Hammer and Project contributors
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * The names of any contributors may not be used to endorse or promote
+              products derived from this software without specific prior written
+              permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                          *   *   *
+
+        The complete list of contributors can be found at: https://github.com/hueniverse/sntp/graphs/contributors
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:30 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/dominictarr/config-chain/master/LICENCE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"171dd970053ce33587ab3960a61b9cb56a9313d6"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - DC0E:72AF:5298:5A15:5AD6766E
+      Content-Length:
+      - '646'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:30 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18650-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004470.343366,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - f032d0b8aaa44440cfcaf0f23f36bf3469daee99
+      Expires:
+      - Tue, 17 Apr 2018 22:39:30 GMT
+      Source-Age:
+      - '8'
+    body:
+      encoding: ASCII-8BIT
+      string: "Copyright (c) 2011 Dominic Tarr\n\nPermission is hereby granted, free
+        of charge, \nto any person obtaining a copy of this software and \nassociated
+        documentation files (the \"Software\"), to \ndeal in the Software without
+        restriction, including \nwithout limitation the rights to use, copy, modify,
+        \nmerge, publish, distribute, sublicense, and/or sell \ncopies of the Software,
+        and to permit persons to whom \nthe Software is furnished to do so, \nsubject
+        to the following conditions:\n\nThe above copyright notice and this permission
+        notice \nshall be included in all copies or substantial portions of the Software.\n\nTHE
+        SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, \nEXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \nOF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. \nIN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR \nANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, \nTORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE \nSOFTWARE OR THE USE OR OTHER DEALINGS
+        IN THE SOFTWARE."
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:30 GMT
+- request:
+    method: get
     uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
     body:
       encoding: US-ASCII
@@ -37,35 +461,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - D5D8:2D30:551C1:5A111:5ACF788E
+      - 23CE:1727:1ABBB:1C21E:5AD6766D
       Content-Length:
       - '680'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:41 GMT
+      - Tue, 17 Apr 2018 22:34:30 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18640-DFW
+      - cache-dfw18633-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
       - '1'
       X-Timer:
-      - S1523546261.122211,VS0,VE1
+      - S1524004471.652167,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 80f1b526524d680d89043f674ecee5bc9ad429e9
+      - c8a5d8056006cbd88e2d41c5d40ee31d85851c3d
       Expires:
-      - Thu, 12 Apr 2018 15:22:41 GMT
+      - Tue, 17 Apr 2018 22:39:30 GMT
       Source-Age:
-      - '5'
+      - '8'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -89,7 +513,7 @@ http_interactions:
         # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         # THE SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:41 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:30 GMT
 - request:
     method: get
     uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -116,7 +540,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:41 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:30 GMT
 - request:
     method: get
     uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -138,7 +562,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 12 Apr 2018 15:17:36 GMT
+      - Tue, 17 Apr 2018 22:34:28 GMT
       Content-Type:
       - text/html; charset=utf-8
       Status:
@@ -156,7 +580,7 @@ http_interactions:
       Location:
       - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
       X-Runtime:
-      - '0.074084'
+      - '0.059190'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Frame-Options:
@@ -177,20 +601,20 @@ http_interactions:
         frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
         collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
-        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+        style-src ''unsafe-inline'' assets-cdn.github.com'
       X-Runtime-Rack:
-      - '0.082005'
+      - '0.066306'
       Age:
-      - '5'
+      - '2'
       Content-Length:
       - '136'
       X-Github-Request-Id:
-      - DAEE:4383:8347AB:F8A910:5ACF7895
+      - CBEF:605D:D71130:1AAE81E:5AD67676
     body:
       encoding: UTF-8
       string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:41 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:30 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
@@ -228,35 +652,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - BB04:0496:28209:2A70A:5ACF788F
+      - EFFE:0950:4CBC0:4FC03:5AD6766E
       Content-Length:
       - '490'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:41 GMT
+      - Tue, 17 Apr 2018 22:34:31 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18638-DFW
+      - cache-dfw18627-DFW
       X-Cache:
       - HIT
       X-Cache-Hits:
       - '1'
       X-Timer:
-      - S1523546262.780622,VS0,VE1
+      - S1524004471.096155,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 4d428c54615a8685d420ccd7fe4d4d3fb76336bc
+      - 3bd084a0fffc597e936cfe869d2f79f05c2fc273
       Expires:
-      - Thu, 12 Apr 2018 15:22:41 GMT
+      - Tue, 17 Apr 2018 22:39:31 GMT
       Source-Age:
-      - '5'
+      - '8'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -276,5 +700,144 @@ http_interactions:
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:41 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:31 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:31 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '2'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18624-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - e51c3c25fe67da36460f25627ce387dfed45ada4
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:31 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"d3f46f7e145990dad5954d78c5da9a2c2bdcbe36"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6424:5053:34333:36FB6:5AD6766F
+      Content-Length:
+      - '666'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:31 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18637-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004471.456705,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - '058d6b889ddf1e6a052250c9f023905fa4423952'
+      Expires:
+      - Tue, 17 Apr 2018 22:39:31 GMT
+      Source-Age:
+      - '7'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:31 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_dependencies_with_no_license_info.yml
+++ b/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/detects_dependencies_with_no_license_info.yml
@@ -2,6 +2,430 @@
 http_interactions:
 - request:
     method: get
+    uri: https://raw.github.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:21 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18627-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 07e76a861d9dedb8e4f1101bca2660ad5632a852
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:21 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"8c84e398668b79fbb7243523cbabe02be58029ee"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6A36:30FB:304F4:31F80:5AD6766D
+      Content-Length:
+      - '672'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:21 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18634-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1524004461.426871,VS0,VE82
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 6a28c27849edbcd7b27d4f3e00e9ebc3cac775c3
+      Expires:
+      - Tue, 17 Apr 2018 22:39:21 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:21 GMT
+- request:
+    method: get
+    uri: http://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:21 GMT
+- request:
+    method: get
+    uri: https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:21 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+      X-Runtime:
+      - '0.041823'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.047208'
+      Age:
+      - '0'
+      Content-Length:
+      - '130'
+      X-Github-Request-Id:
+      - CBC6:605B:852ACF:113192A:5AD6766D
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:21 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"6dc3e82d3c2e9b7a4e005075c965de4e32c72eb7"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 4F6C:1722:38D63:3C025:5AD6766D
+      Content-Length:
+      - '865'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:22 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18629-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1524004462.105297,VS0,VE72
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 1b34e629669274d76fed0b79e9e7911cbc397f54
+      Expires:
+      - Tue, 17 Apr 2018 22:39:22 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        Copyright (c) 2012-2016, Eran Hammer and Project contributors
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * The names of any contributors may not be used to endorse or promote
+              products derived from this software without specific prior written
+              permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                          *   *   *
+
+        The complete list of contributors can be found at: https://github.com/hueniverse/sntp/graphs/contributors
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:22 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/dominictarr/config-chain/master/LICENCE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"171dd970053ce33587ab3960a61b9cb56a9313d6"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - DC0E:72AF:5298:5A15:5AD6766E
+      Content-Length:
+      - '646'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:22 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18629-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1524004462.455556,VS0,VE74
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 25fc0fae25c2c06cb2dea489dbe1ad58ef8d6a3d
+      Expires:
+      - Tue, 17 Apr 2018 22:39:22 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: "Copyright (c) 2011 Dominic Tarr\n\nPermission is hereby granted, free
+        of charge, \nto any person obtaining a copy of this software and \nassociated
+        documentation files (the \"Software\"), to \ndeal in the Software without
+        restriction, including \nwithout limitation the rights to use, copy, modify,
+        \nmerge, publish, distribute, sublicense, and/or sell \ncopies of the Software,
+        and to permit persons to whom \nthe Software is furnished to do so, \nsubject
+        to the following conditions:\n\nThe above copyright notice and this permission
+        notice \nshall be included in all copies or substantial portions of the Software.\n\nTHE
+        SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, \nEXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \nOF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. \nIN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR \nANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, \nTORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE \nSOFTWARE OR THE USE OR OTHER DEALINGS
+        IN THE SOFTWARE."
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:22 GMT
+- request:
+    method: get
     uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
     body:
       encoding: US-ASCII
@@ -37,35 +461,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - D5D8:2D30:551C1:5A111:5ACF788E
+      - 23CE:1727:1ABBB:1C21E:5AD6766D
       Content-Length:
       - '680'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:37 GMT
+      - Tue, 17 Apr 2018 22:34:22 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18628-DFW
+      - cache-dfw18650-DFW
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Timer:
-      - S1523546257.432656,VS0,VE1
+      - S1524004463.891185,VS0,VE60
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 2c816fc54132eb1e376a5dcc917e4da0ef3bcbda
+      - 47a78423be2fc19f52fbb864b8bdb8490cb14ca2
       Expires:
-      - Thu, 12 Apr 2018 15:22:37 GMT
+      - Tue, 17 Apr 2018 22:39:22 GMT
       Source-Age:
-      - '2'
+      - '0'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -89,7 +513,7 @@ http_interactions:
         # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         # THE SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:37 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:22 GMT
 - request:
     method: get
     uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -116,7 +540,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:37 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:23 GMT
 - request:
     method: get
     uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -138,7 +562,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 12 Apr 2018 15:17:37 GMT
+      - Tue, 17 Apr 2018 22:34:23 GMT
       Content-Type:
       - text/html; charset=utf-8
       Status:
@@ -156,7 +580,7 @@ http_interactions:
       Location:
       - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
       X-Runtime:
-      - '0.044812'
+      - '0.058411'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Frame-Options:
@@ -177,20 +601,20 @@ http_interactions:
         frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
         collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
-        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+        style-src ''unsafe-inline'' assets-cdn.github.com'
       X-Runtime-Rack:
-      - '0.050032'
+      - '0.063980'
       Age:
       - '0'
       Content-Length:
       - '136'
       X-Github-Request-Id:
-      - DAE6:4384:B05810:143686B:5ACF7891
+      - CBCB:605C:AA522B:15C6BCF:5AD6766F
     body:
       encoding: UTF-8
       string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:37 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:23 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
@@ -228,35 +652,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - BB04:0496:28209:2A70A:5ACF788F
+      - EFFE:0950:4CBC0:4FC03:5AD6766E
       Content-Length:
       - '490'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:37 GMT
+      - Tue, 17 Apr 2018 22:34:23 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18630-DFW
+      - cache-dfw18643-DFW
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Timer:
-      - S1523546258.941170,VS0,VE1
+      - S1524004463.484697,VS0,VE68
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - e341ed778626d0a4b585687ace9cff821cbdbd1b
+      - 4dc2f49d42ef3cbb1296ff9323fffe3e460666eb
       Expires:
-      - Thu, 12 Apr 2018 15:22:37 GMT
+      - Tue, 17 Apr 2018 22:39:23 GMT
       Source-Age:
-      - '1'
+      - '0'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -276,5 +700,144 @@ http_interactions:
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:37 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:23 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:23 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18638-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 73f6ce06ced3f170edc4e0e1e3cfa6627a07e989
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:23 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"d3f46f7e145990dad5954d78c5da9a2c2bdcbe36"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6424:5053:34333:36FB6:5AD6766F
+      Content-Length:
+      - '666'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:24 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18626-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1524004464.958915,VS0,VE63
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - d989de422fbb968faae37745f0c7ea17877968a5
+      Expires:
+      - Tue, 17 Apr 2018 22:39:24 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:24 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/handles_licenses_with_multiple_combined_license_terms.yml
+++ b/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Npm/_dependencies/handles_licenses_with_multiple_combined_license_terms.yml
@@ -2,6 +2,430 @@
 http_interactions:
 - request:
     method: get
+    uri: https://raw.github.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:26 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18637-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - eb688ed436f096c5c93b282fc13a7abb96bc2889
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:26 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-uuid/master/LICENSE.md
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"8c84e398668b79fbb7243523cbabe02be58029ee"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6A36:30FB:304F4:31F80:5AD6766D
+      Content-Length:
+      - '672'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:27 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18643-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004467.006004,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 58763f59fe4a32c889d9be6f4f808afaeecd2c0a
+      Expires:
+      - Tue, 17 Apr 2018 22:39:27 GMT
+      Source-Age:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:27 GMT
+- request:
+    method: get
+    uri: http://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Content-Length:
+      - '0'
+      Location:
+      - https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:27 GMT
+- request:
+    method: get
+    uri: https://github.com/hueniverse/sntp/raw/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 302
+      message: Found
+    headers:
+      Server:
+      - GitHub.com
+      Date:
+      - Tue, 17 Apr 2018 22:34:27 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Status:
+      - 302 Found
+      Cache-Control:
+      - no-cache
+      Vary:
+      - X-PJAX
+      X-Ratelimit-Limit:
+      - '100'
+      X-Ratelimit-Remaining:
+      - '100'
+      Access-Control-Allow-Origin:
+      - https://render.githubusercontent.com
+      Location:
+      - https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+      X-Runtime:
+      - '0.043964'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      X-Frame-Options:
+      - deny
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Expect-Ct:
+      - max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"
+      Content-Security-Policy:
+      - 'default-src ''none''; base-uri ''self''; block-all-mixed-content; child-src
+        render.githubusercontent.com; connect-src ''self'' uploads.github.com status.github.com
+        collector.githubapp.com api.github.com www.google-analytics.com github-cloud.s3.amazonaws.com
+        github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com
+        github-production-user-asset-6210df.s3.amazonaws.com wss://live.github.com;
+        font-src assets-cdn.github.com; form-action ''self'' github.com gist.github.com;
+        frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
+        collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
+        manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
+        style-src ''unsafe-inline'' assets-cdn.github.com'
+      X-Runtime-Rack:
+      - '0.048717'
+      Age:
+      - '0'
+      Content-Length:
+      - '130'
+      X-Github-Request-Id:
+      - CBDE:605B:852C6E:1131C7D:5AD67673
+    body:
+      encoding: UTF-8
+      string: <html><body>You are being <a href="https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE">redirected</a>.</body></html>
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:27 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/hueniverse/sntp/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"6dc3e82d3c2e9b7a4e005075c965de4e32c72eb7"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 4F6C:1722:38D63:3C025:5AD6766D
+      Content-Length:
+      - '865'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:27 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18635-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004468.560770,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - 1225bc3dd39c9d69d71610a1f2f4b3bbd05fd3bd
+      Expires:
+      - Tue, 17 Apr 2018 22:39:27 GMT
+      Source-Age:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        Copyright (c) 2012-2016, Eran Hammer and Project contributors
+        All rights reserved.
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * The names of any contributors may not be used to endorse or promote
+              products derived from this software without specific prior written
+              permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+        ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+                                          *   *   *
+
+        The complete list of contributors can be found at: https://github.com/hueniverse/sntp/graphs/contributors
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:27 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/dominictarr/config-chain/master/LICENCE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"171dd970053ce33587ab3960a61b9cb56a9313d6"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - DC0E:72AF:5298:5A15:5AD6766E
+      Content-Length:
+      - '646'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:27 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18623-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004468.822133,VS0,VE0
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - f2e006cbf12d0dacf23f9af0efc4b5b936cb809d
+      Expires:
+      - Tue, 17 Apr 2018 22:39:27 GMT
+      Source-Age:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: "Copyright (c) 2011 Dominic Tarr\n\nPermission is hereby granted, free
+        of charge, \nto any person obtaining a copy of this software and \nassociated
+        documentation files (the \"Software\"), to \ndeal in the Software without
+        restriction, including \nwithout limitation the rights to use, copy, modify,
+        \nmerge, publish, distribute, sublicense, and/or sell \ncopies of the Software,
+        and to permit persons to whom \nthe Software is furnished to do so, \nsubject
+        to the following conditions:\n\nThe above copyright notice and this permission
+        notice \nshall be included in all copies or substantial portions of the Software.\n\nTHE
+        SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, \nEXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES \nOF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. \nIN NO EVENT SHALL
+        THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR \nANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, \nTORT OR OTHERWISE, ARISING
+        FROM, OUT OF OR IN CONNECTION WITH THE \nSOFTWARE OR THE USE OR OTHER DEALINGS
+        IN THE SOFTWARE."
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:27 GMT
+- request:
+    method: get
     uri: https://raw.githubusercontent.com/3rd-Eden/useragent/master/LICENSE
     body:
       encoding: US-ASCII
@@ -37,35 +461,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - D5D8:2D30:551C1:5A111:5ACF788E
+      - 23CE:1727:1ABBB:1C21E:5AD6766D
       Content-Length:
       - '680'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:35 GMT
+      - Tue, 17 Apr 2018 22:34:28 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18636-DFW
+      - cache-dfw18620-DFW
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       X-Timer:
-      - S1523546256.835057,VS0,VE86
+      - S1524004468.131554,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - cc0787b0c7f903b5634e57bb679367587321693a
+      - ab6ca636abb29da16880a46badce0946328ff172
       Expires:
-      - Thu, 12 Apr 2018 15:22:35 GMT
+      - Tue, 17 Apr 2018 22:39:28 GMT
       Source-Age:
-      - '0'
+      - '5'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -89,7 +513,7 @@ http_interactions:
         # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         # THE SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:35 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:28 GMT
 - request:
     method: get
     uri: http://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -116,7 +540,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:36 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:28 GMT
 - request:
     method: get
     uri: https://github.com/isaacs/node-lru-cache/raw/master/LICENSE
@@ -138,7 +562,7 @@ http_interactions:
       Server:
       - GitHub.com
       Date:
-      - Thu, 12 Apr 2018 15:17:36 GMT
+      - Tue, 17 Apr 2018 22:34:28 GMT
       Content-Type:
       - text/html; charset=utf-8
       Status:
@@ -156,7 +580,7 @@ http_interactions:
       Location:
       - https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
       X-Runtime:
-      - '0.074084'
+      - '0.059190'
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       X-Frame-Options:
@@ -177,20 +601,20 @@ http_interactions:
         frame-ancestors ''none''; img-src ''self'' data: assets-cdn.github.com identicons.github.com
         collector.githubapp.com github-cloud.s3.amazonaws.com *.githubusercontent.com;
         manifest-src ''self''; media-src ''none''; script-src assets-cdn.github.com;
-        style-src ''unsafe-inline'' assets-cdn.github.com; worker-src ''self'''
+        style-src ''unsafe-inline'' assets-cdn.github.com'
       X-Runtime-Rack:
-      - '0.082005'
+      - '0.066306'
       Age:
       - '0'
       Content-Length:
       - '136'
       X-Github-Request-Id:
-      - DAE1:4385:CF9FBF:174DBA6:5ACF7890
+      - CBE3:605C:AA54A5:15C7090:5AD67674
     body:
       encoding: UTF-8
       string: <html><body>You are being <a href="https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE">redirected</a>.</body></html>
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:36 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:28 GMT
 - request:
     method: get
     uri: https://raw.githubusercontent.com/isaacs/node-lru-cache/master/LICENSE
@@ -228,35 +652,35 @@ http_interactions:
       X-Geo-Block-List:
       - ''
       X-Github-Request-Id:
-      - BB04:0496:28209:2A70A:5ACF788F
+      - EFFE:0950:4CBC0:4FC03:5AD6766E
       Content-Length:
       - '490'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 12 Apr 2018 15:17:36 GMT
+      - Tue, 17 Apr 2018 22:34:28 GMT
       Via:
       - 1.1 varnish
       Connection:
       - keep-alive
       X-Served-By:
-      - cache-dfw18624-DFW
+      - cache-dfw18642-DFW
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       X-Timer:
-      - S1523546257.508770,VS0,VE67
+      - S1524004469.652303,VS0,VE1
       Vary:
       - Authorization,Accept-Encoding
       Access-Control-Allow-Origin:
       - "*"
       X-Fastly-Request-Id:
-      - 07a0cfbe0c08dea934b43f5fe05e6f007a717946
+      - 5ef3be6b678b8bb61ab5bf7db75db0ef6dd5b31e
       Expires:
-      - Thu, 12 Apr 2018 15:22:36 GMT
+      - Tue, 17 Apr 2018 22:39:28 GMT
       Source-Age:
-      - '0'
+      - '5'
     body:
       encoding: ASCII-8BIT
       string: |
@@ -276,5 +700,144 @@ http_interactions:
         ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
         IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     http_version: 
-  recorded_at: Thu, 12 Apr 2018 15:17:36 GMT
+  recorded_at: Tue, 17 Apr 2018 22:34:28 GMT
+- request:
+    method: get
+    uri: https://raw.github.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 301
+      message: Moved Permanently
+    headers:
+      Location:
+      - https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+      Content-Length:
+      - '0'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:28 GMT
+      Via:
+      - 1.1 varnish
+      Age:
+      - '0'
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18649-DFW
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      Vary:
+      - Accept-Encoding
+      X-Fastly-Request-Id:
+      - 31dd60c08cee40ab1a2bc1b7277491129a14a8d2
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:28 GMT
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/broofa/node-mime/master/LICENSE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      Etag:
+      - '"d3f46f7e145990dad5954d78c5da9a2c2bdcbe36"'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cache-Control:
+      - max-age=300
+      X-Geo-Block-List:
+      - ''
+      X-Github-Request-Id:
+      - 6424:5053:34333:36FB6:5AD6766F
+      Content-Length:
+      - '666'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 17 Apr 2018 22:34:29 GMT
+      Via:
+      - 1.1 varnish
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-dfw18644-DFW
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1524004469.041109,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Fastly-Request-Id:
+      - ef864f604af2128a544afa068a83ca515c4d70af
+      Expires:
+      - Tue, 17 Apr 2018 22:39:29 GMT
+      Source-Age:
+      - '5'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        The MIT License (MIT)
+
+        Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+    http_version: 
+  recorded_at: Tue, 17 Apr 2018 22:34:29 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
* Properly detect the multiple license keys used in package.json
* Handle https -> http redirects when downloading license content

Signed-off-by: Tom Duffield <tom@chef.io>