### PR TITLE
Few more cleanups from the 2.0 refactor

### DIFF
--- a/bin/gemfile_json
+++ b/bin/gemfile_json
@@ -1,3 +1,4 @@
+#!/usr/bin/env ruby
 #
 # Copyright:: Copyright 2016, Chef Software Inc.
 # License:: Apache License, Version 2.0

--- a/lib/license_scout/cli.rb
+++ b/lib/license_scout/cli.rb
@@ -64,10 +64,8 @@ module LicenseScout
 
       LicenseScout::Config.merge!(config)
 
+      Mixlib::Log::Formatter.show_time = false
       LicenseScout::Log.level = LicenseScout::Config.log_level
-      LicenseScout::Log.formatter = proc do |sev, datetime, progname, msg|
-        "#{sev.ljust(5)} #{msg}\n"
-      end
 
       LicenseScout::Config.config_files.each do |config_file|
         if config_file =~ /^http/
@@ -82,8 +80,13 @@ module LicenseScout
           end
         else
           full_config_file = File.expand_path(config_file)
-          LicenseScout::Log.info("[cli] Loading config from #{full_config_file}")
-          LicenseScout::Config.from_file(full_config_file)
+
+          if File.exist?(full_config_file)
+            LicenseScout::Log.info("[cli] Loading config from #{full_config_file}")
+            LicenseScout::Config.from_file(full_config_file)
+          else
+            LicenseScout::Log.info("[cli] Could not find file #{full_config_file} -- skipping")
+          end
         end
       end
 

--- a/lib/license_scout/dependency_manager/bundler.rb
+++ b/lib/license_scout/dependency_manager/bundler.rb
@@ -81,11 +81,11 @@ module LicenseScout
       private
 
       def dependency_data
-        bundler_script = File.join(File.dirname(__FILE__), "bundler/_bundler_script.rb")
+        gemfile_to_json_path = File.expand_path("../../../bin/gemfile_json", File.dirname(__FILE__))
 
         Dir.chdir(directory) do
           json_dep_data = with_clean_env do
-            s = Mixlib::ShellOut.new("#{LicenseScout::Config.ruby_bin} #{bundler_script}", environment: LicenseScout::Config.environment)
+            s = Mixlib::ShellOut.new("#{LicenseScout::Config.ruby_bin} #{gemfile_to_json_path}", environment: LicenseScout::Config.environment)
             s.run_command
             s.error!
             s.stdout


### PR DESCRIPTION
* Use the new Formatter that comes with mixlib-log
* Move the bundler script into bin and rename it like other native parsing bins