### PR TITLE
Fix Habitat build - Gemfile.lock does not exist

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -74,7 +74,6 @@ do_install() {
 
   build_line "Moving License Scout gem into place"
   cp -R "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib" "$pkg_prefix/lib"
-  install -m 0644 "$HAB_CACHE_SRC_PATH/$pkg_dirname/Gemfile.lock" "$pkg_prefix/Gemfile.lock"
   install -m 0644 "$HAB_CACHE_SRC_PATH/$pkg_dirname/Gemfile" "$pkg_prefix/Gemfile"
   install -m 0644 "$HAB_CACHE_SRC_PATH/$pkg_dirname/$pkg_name.gemspec" "$pkg_prefix/$pkg_name.gemspec"
 


### PR DESCRIPTION
The 'bundle install' process is the thing that creates the Gemfile.lock.
As such, we do not need to move it during the initial setup. This was
a copy-paste error that was hidden by the fact that my local dev env
has a Gemfile.lock from my local development.

Signed-off-by: Tom Duffield <tom@chef.io>