### PR TITLE
Support exporting Dependency Manifest to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ license_content | A URL to a file where the raw text of the license can be downl
 
 In addition to including any files Licensee identified as potential license files (but couldn't identify), License Scout will also include the Fallback License you specified in the Dependency Manifest.
 
+## Exporting a Dependency Manifest to another format
+
+By default, License Scout creates the Dependency Manifest as a JSON file. We do this because it provides a single document that can be easily processed into many different forms. License Scout has the ability to also export that JSON file into other formats.
+
+### Usage
+
+```
+license_scout export [PATH_TO_JSON_FILE] --format FORMAT
+```
+### Support Formats
+
+Format | Description
+--- | ---
+`csv` | Export the contents of the JSON file into a CSV.
+
+
 ## Configuration
 
 Value | Description | Default

--- a/lib/license_scout/exporter.rb
+++ b/lib/license_scout/exporter.rb
@@ -1,0 +1,51 @@
+#
+# Copyright:: Copyright 2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "license_scout/exporter/csv"
+
+module LicenseScout
+  class Exporter
+
+    attr_reader :json_file
+    attr_reader :export_format
+    attr_reader :exporter
+
+    def initialize(json_file, export_format)
+      @json_file = json_file
+      @export_format = export_format
+
+      @exporter = case export_format
+                  when "csv"
+                    LicenseScout::Exporter::CSV.new(json_file)
+                  else
+                    # We shouldn't ever hit this, because the CLI filters out unsupported formats. But just in case...
+                    raise LicenseScout::Exceptions::UnsupportedExporter.new("'#{export_format}' is not a supported format. Please use one of the following: #{supported_formats.join(", ")}")
+                  end
+    end
+
+    def self.supported_formats
+      [
+        "csv",
+      ]
+    end
+
+    def export
+      LicenseScout::Log.info("[exporter] Exporting #{json_file} to '#{export_format}'")
+      exporter.export
+    end
+  end
+end

--- a/lib/license_scout/exporter/csv.rb
+++ b/lib/license_scout/exporter/csv.rb
@@ -1,0 +1,76 @@
+#
+# Copyright:: Copyright 2016, Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "csv"
+
+module LicenseScout
+  class Exporter
+    class CSV
+
+      attr_reader :json
+      attr_reader :output_file
+
+      def initialize(json_file)
+        @json = FFI_Yajl::Parser.parse(File.read(json_file))
+        @output_file = json_file.gsub("json", "csv")
+      end
+
+      def export
+        headers = [
+          "Type",
+          "Name",
+          "Version",
+          "Has Exception",
+          "Exception Reason",
+          "License ID",
+          "License Source",
+          "License Content",
+        ]
+
+        ::CSV.open(output_file, "w+") do |csv|
+          csv << headers
+
+          json["dependencies"].each do |dependency|
+            type = dependency["type"]
+            name = dependency["name"]
+            version = dependency["version"]
+            has_exception = dependency["has_exception"]
+            exception_reason = dependency["exception_reason"]
+            licenses = dependency["licenses"]
+
+            licenses.each do |license|
+              id = license["id"]
+              source = license["source"]
+              content = license["content"]
+
+              csv << [
+                type,
+                name,
+                version,
+                (has_exception.nil? ? "Yes" : "No"),
+                (exception_reason.nil? ? "" : exception_reason),
+                id,
+                source,
+                content
+              ]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/license_scout/exporter_spec.rb
+++ b/spec/license_scout/exporter_spec.rb
@@ -1,12 +1,12 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright 2018 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,11 +15,8 @@
 # limitations under the License.
 #
 
-module LicenseScout
-  module Exceptions
-    class Error < RuntimeError; end
-    class ConfigError < Error; end
-    class MissingSourceDirectory < Error; end
-    class UnsupportedExporter < Error; end
+RSpec.describe LicenseScout::Exporter do
+  it "has a limited list of supported formats" do
+    expect(described_class.supported_formats).to eql(["csv"])
   end
 end


### PR DESCRIPTION
This introduces a new code path of allowing us to export the Dependency
Manifest JSON file into a number of other formats. The first format we
are supporting is CSV.

Signed-off-by: Tom Duffield <tom@chef.io>