### PR TITLE
Remove override for Devel-PPPort

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -450,7 +450,6 @@ module LicenseScout
         ["URI-Nested", nil, ["README.md"]],
         ["Test-utf8", nil, ["README"]],
         ["Class-Singleton", "Perl-5", ["README"]],
-        ["Devel-PPPort", nil, ["README"]],
         ["Digest-SHA1", nil, ["README"]],
         ["JSON-PP", nil, ["README"]],
         ["MRO-Compat", nil, ["README"]],


### PR DESCRIPTION
Devel-PPPort 3.42 removed the README file breaking things. It's had a META.yml with
licensing info (perl) for a few versions so this should be safe.

Signed-off-by: Mark Anderson <mark@chef.io>