### PR TITLE
Fix Devel::PPPort

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -450,6 +450,7 @@ module LicenseScout
         ["URI-Nested", nil, ["README.md"]],
         ["Test-utf8", nil, ["README"]],
         ["Class-Singleton", "Perl-5", ["README"]],
+        ["Devel-PPPort", "Perl-5", ["Makefile.PL"]],
         ["Digest-SHA1", nil, ["README"]],
         ["JSON-PP", nil, ["README"]],
         ["MRO-Compat", nil, ["README"]],


### PR DESCRIPTION
Devel::PPPort 3.42 removed the README file, which presumably carried
the license info. The Makefile.PL contains a note about the license,
and the META.yml notes the license to be perl, but there's no actual
license anywhere.

Signed-off-by: Mark Anderson <mark@chef.io>