### PR TITLE
Revert "Add json gem override"

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -300,7 +300,6 @@ module LicenseScout
         ["timeliness", "MIT", ["LICENSE"]],
         # Overrides that require file fetching from internet
         ["sfl", "Ruby", ["https://raw.githubusercontent.com/ujihisa/spawn-for-legacy/master/LICENCE.md"]],
-        ["json", "Ruby", ["http://www.ruby-lang.org/en/LICENSE.txt"]],
         ["json_pure", nil, ["https://raw.githubusercontent.com/flori/json/master/README.md"]],
         ["aws-sdk-core", nil, ["https://raw.githubusercontent.com/aws/aws-sdk-ruby/master/README.md"]],
         ["aws-sdk-resources", nil, ["https://raw.githubusercontent.com/aws/aws-sdk-ruby/master/README.md"]],


### PR DESCRIPTION
This gem should be handled here:
https://github.com/chef/license_scout/blob/1-stable/lib/license_scout/dependency_manager/bundler.rb#L75-L83

This reverts commit ee06ff79ce2514ca52adf6c93f59a9b6ba82ff13.