### PR TITLE
Update LicenseScout deps & improve error handling

### DIFF
--- a/lib/license_scout/data/exceptions.json
+++ b/lib/license_scout/data/exceptions.json
@@ -1,6 +1,6 @@
 {
-  "licenseListVersion": "3.0",
-  "releaseDate": "28 December 2017",
+  "licenseListVersion": "3.1",
+  "releaseDate": "2018-04-14",
   "exceptions": [
     {
       "reference": "./389-exception.html",
@@ -214,10 +214,21 @@
       "licenseExceptionId": "Linux-syscall-note"
     },
     {
+      "reference": "./LLVM-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LLVM-exception.json",
+      "referenceNumber": "20",
+      "name": "LLVM Exception",
+      "seeAlso": [
+        "http://llvm.org/foundation/relicensing/LICENSE.txt"
+      ],
+      "licenseExceptionId": "LLVM-exception"
+    },
+    {
       "reference": "./LZMA-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LZMA-exception.json",
-      "referenceNumber": "20",
+      "referenceNumber": "21",
       "name": "LZMA exception",
       "seeAlso": [
         "http://nsis.sourceforge.net/Docs/AppendixI.html#I.6"
@@ -228,11 +239,12 @@
       "reference": "./mif-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/mif-exception.json",
-      "referenceNumber": "21",
+      "referenceNumber": "22",
       "name": "Macros and Inline Functions Exception",
       "seeAlso": [
         "http://www.scs.stanford.edu/histar/src/lib/cppsup/exception",
-        "http://dev.bertos.org/doxygen/ https://www.threadingbuildingblocks.org/licensing"
+        "http://dev.bertos.org/doxygen/",
+        "https://www.threadingbuildingblocks.org/licensing"
       ],
       "licenseExceptionId": "mif-exception"
     },
@@ -240,7 +252,7 @@
       "reference": "./Nokia-Qt-exception-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Nokia-Qt-exception-1.1.json",
-      "referenceNumber": "22",
+      "referenceNumber": "23",
       "name": "Nokia Qt LGPL exception 1.1",
       "seeAlso": [
         "https://www.keepassx.org/dev/projects/keepassx/repository/revisions/b8dfb9cc4d5133e0f09cd7533d15a4f1c19a40f2/entry/LICENSE.NOKIA-LGPL-EXCEPTION"
@@ -251,7 +263,7 @@
       "reference": "./OCCT-exception-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCCT-exception-1.0.json",
-      "referenceNumber": "23",
+      "referenceNumber": "24",
       "name": "Open CASCADE Exception 1.0",
       "seeAlso": [
         "http://www.opencascade.com/content/licensing"
@@ -259,10 +271,21 @@
       "licenseExceptionId": "OCCT-exception-1.0"
     },
     {
+      "reference": "./OpenJDK-assembly-exception-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OpenJDK-assembly-exception-1.0.json",
+      "referenceNumber": "25",
+      "name": "OpenJDK Assembly exception 1.0",
+      "seeAlso": [
+        "http://openjdk.java.net/legal/assembly-exception.html\n         "
+      ],
+      "licenseExceptionId": "OpenJDK-assembly-exception-1.0"
+    },
+    {
       "reference": "./openvpn-openssl-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/openvpn-openssl-exception.json",
-      "referenceNumber": "24",
+      "referenceNumber": "26",
       "name": "OpenVPN OpenSSL Exception",
       "seeAlso": [
         "http://openvpn.net/index.php/license.html"
@@ -273,7 +296,7 @@
       "reference": "./Qwt-exception-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Qwt-exception-1.0.json",
-      "referenceNumber": "25",
+      "referenceNumber": "27",
       "name": "Qwt exception 1.0",
       "seeAlso": [
         "http://qwt.sourceforge.net/qwtlicense.html"
@@ -284,7 +307,7 @@
       "reference": "./u-boot-exception-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/u-boot-exception-2.0.json",
-      "referenceNumber": "26",
+      "referenceNumber": "28",
       "name": "U-Boot exception 2.0",
       "seeAlso": [
         "http://git.denx.de/?p\u003du-boot.git;a\u003dblob;f\u003dLicenses/Exceptions"
@@ -295,7 +318,7 @@
       "reference": "./WxWindows-exception-3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/WxWindows-exception-3.1.json",
-      "referenceNumber": "27",
+      "referenceNumber": "29",
       "name": "WxWindows Library Exception 3.1",
       "seeAlso": [
         "http://www.opensource.org/licenses/WXwindows"

--- a/lib/license_scout/data/licenses.json
+++ b/lib/license_scout/data/licenses.json
@@ -1,5 +1,5 @@
 {
-  "licenseListVersion": "3.0",
+  "licenseListVersion": "3.1",
   "licenses": [
     {
       "reference": "./0BSD.html",
@@ -155,13 +155,24 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./AGPL-1.0.html",
+      "reference": "./AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
+      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
       "referenceNumber": "13",
-      "name": "Affero General Public License v1.0",
-      "licenseId": "AGPL-1.0",
+      "name": "Affero General Public License v1.0 only",
+      "licenseId": "AGPL-1.0-only",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./AGPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
+      "referenceNumber": "14",
+      "name": "Affero General Public License v1.0 or later",
+      "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
         "http://www.affero.org/oagpl.html"
       ],
@@ -170,8 +181,9 @@
     {
       "reference": "./AGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": "14",
+      "referenceNumber": "15",
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
@@ -183,8 +195,9 @@
     {
       "reference": "./AGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": "15",
+      "referenceNumber": "16",
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
@@ -196,9 +209,8 @@
     {
       "reference": "./Aladdin.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": "16",
+      "referenceNumber": "17",
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -210,7 +222,7 @@
       "reference": "./AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": "17",
+      "referenceNumber": "18",
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -222,7 +234,7 @@
       "reference": "./AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AML.json",
-      "referenceNumber": "18",
+      "referenceNumber": "19",
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -234,7 +246,7 @@
       "reference": "./AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": "19",
+      "referenceNumber": "20",
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -246,7 +258,7 @@
       "reference": "./ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": "20",
+      "referenceNumber": "21",
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -259,7 +271,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": "21",
+      "referenceNumber": "22",
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -272,7 +284,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": "22",
+      "referenceNumber": "23",
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
@@ -286,7 +298,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": "23",
+      "referenceNumber": "24",
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
@@ -299,7 +311,7 @@
       "reference": "./APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APAFML.json",
-      "referenceNumber": "24",
+      "referenceNumber": "25",
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -311,7 +323,7 @@
       "reference": "./APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": "25",
+      "referenceNumber": "26",
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
@@ -322,9 +334,8 @@
     {
       "reference": "./APSL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": "26",
+      "referenceNumber": "27",
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -336,7 +347,7 @@
       "reference": "./APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": "27",
+      "referenceNumber": "28",
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -348,7 +359,7 @@
       "reference": "./APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": "28",
+      "referenceNumber": "29",
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -361,7 +372,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": "29",
+      "referenceNumber": "30",
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -373,7 +384,7 @@
       "reference": "./Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": "30",
+      "referenceNumber": "31",
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
@@ -385,7 +396,7 @@
       "reference": "./Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": "31",
+      "referenceNumber": "32",
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -396,9 +407,8 @@
     {
       "reference": "./Artistic-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": "32",
+      "referenceNumber": "33",
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
@@ -411,7 +421,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": "33",
+      "referenceNumber": "34",
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
@@ -424,7 +434,7 @@
       "reference": "./Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": "34",
+      "referenceNumber": "35",
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -436,7 +446,7 @@
       "reference": "./Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Barr.json",
-      "referenceNumber": "35",
+      "referenceNumber": "36",
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -448,7 +458,7 @@
       "reference": "./Beerware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Beerware.json",
-      "referenceNumber": "36",
+      "referenceNumber": "37",
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -461,7 +471,7 @@
       "reference": "./BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": "37",
+      "referenceNumber": "38",
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -474,7 +484,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": "38",
+      "referenceNumber": "39",
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -486,7 +496,7 @@
       "reference": "./Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Borceux.json",
-      "referenceNumber": "39",
+      "referenceNumber": "40",
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -498,7 +508,7 @@
       "reference": "./BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": "40",
+      "referenceNumber": "41",
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -511,7 +521,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": "41",
+      "referenceNumber": "42",
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -523,7 +533,7 @@
       "reference": "./BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": "42",
+      "referenceNumber": "43",
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -535,7 +545,7 @@
       "reference": "./BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": "43",
+      "referenceNumber": "44",
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -547,7 +557,7 @@
       "reference": "./BSD-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": "44",
+      "referenceNumber": "45",
       "name": "BSD 2-Clause \"Simplified\" License",
       "licenseId": "BSD-2-Clause",
       "seeAlso": [
@@ -559,7 +569,7 @@
       "reference": "./BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": "45",
+      "referenceNumber": "46",
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -572,7 +582,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": "46",
+      "referenceNumber": "47",
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -584,7 +594,7 @@
       "reference": "./BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": "47",
+      "referenceNumber": "48",
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -596,7 +606,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": "48",
+      "referenceNumber": "49",
       "name": "BSD 3-Clause No Nuclear License 2014",
       "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
       "seeAlso": [
@@ -608,7 +618,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": "49",
+      "referenceNumber": "50",
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -620,7 +630,7 @@
       "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": "50",
+      "referenceNumber": "51",
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -633,7 +643,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": "51",
+      "referenceNumber": "52",
       "name": "BSD 3-Clause \"New\" or \"Revised\" License",
       "licenseId": "BSD-3-Clause",
       "seeAlso": [
@@ -645,7 +655,7 @@
       "reference": "./BSD-4-Clause-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": "52",
+      "referenceNumber": "53",
       "name": "BSD-4-Clause (University of California-Specific)",
       "licenseId": "BSD-4-Clause-UC",
       "seeAlso": [
@@ -658,7 +668,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": "53",
+      "referenceNumber": "54",
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -670,7 +680,7 @@
       "reference": "./BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": "54",
+      "referenceNumber": "55",
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -682,7 +692,7 @@
       "reference": "./BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": "55",
+      "referenceNumber": "56",
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -695,7 +705,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": "56",
+      "referenceNumber": "57",
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
@@ -708,7 +718,7 @@
       "reference": "./bzip2-1.0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": "57",
+      "referenceNumber": "58",
       "name": "bzip2 and libbzip2 License v1.0.5",
       "licenseId": "bzip2-1.0.5",
       "seeAlso": [
@@ -720,7 +730,7 @@
       "reference": "./bzip2-1.0.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": "58",
+      "referenceNumber": "59",
       "name": "bzip2 and libbzip2 License v1.0.6",
       "licenseId": "bzip2-1.0.6",
       "seeAlso": [
@@ -732,7 +742,7 @@
       "reference": "./Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Caldera.json",
-      "referenceNumber": "59",
+      "referenceNumber": "60",
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -744,7 +754,7 @@
       "reference": "./CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": "60",
+      "referenceNumber": "61",
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
@@ -756,8 +766,8 @@
       "reference": "./CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": "61",
-      "name": "Creative Commons Attribution 1.0",
+      "referenceNumber": "62",
+      "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by/1.0/legalcode"
@@ -768,8 +778,8 @@
       "reference": "./CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": "62",
-      "name": "Creative Commons Attribution 2.0",
+      "referenceNumber": "63",
+      "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by/2.0/legalcode"
@@ -780,8 +790,8 @@
       "reference": "./CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": "63",
-      "name": "Creative Commons Attribution 2.5",
+      "referenceNumber": "64",
+      "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
         "http://creativecommons.org/licenses/by/2.5/legalcode"
@@ -792,8 +802,8 @@
       "reference": "./CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": "64",
-      "name": "Creative Commons Attribution 3.0",
+      "referenceNumber": "65",
+      "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by/3.0/legalcode"
@@ -805,8 +815,8 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": "65",
-      "name": "Creative Commons Attribution 4.0",
+      "referenceNumber": "66",
+      "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by/4.0/legalcode"
@@ -816,10 +826,9 @@
     {
       "reference": "./CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": "66",
-      "name": "Creative Commons Attribution Non Commercial 1.0",
+      "referenceNumber": "67",
+      "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc/1.0/legalcode"
@@ -829,10 +838,9 @@
     {
       "reference": "./CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": "67",
-      "name": "Creative Commons Attribution Non Commercial 2.0",
+      "referenceNumber": "68",
+      "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc/2.0/legalcode"
@@ -842,10 +850,9 @@
     {
       "reference": "./CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": "68",
-      "name": "Creative Commons Attribution Non Commercial 2.5",
+      "referenceNumber": "69",
+      "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc/2.5/legalcode"
@@ -855,10 +862,9 @@
     {
       "reference": "./CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": "69",
-      "name": "Creative Commons Attribution Non Commercial 3.0",
+      "referenceNumber": "70",
+      "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc/3.0/legalcode"
@@ -868,10 +874,9 @@
     {
       "reference": "./CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": "70",
-      "name": "Creative Commons Attribution Non Commercial 4.0",
+      "referenceNumber": "71",
+      "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc/4.0/legalcode"
@@ -882,8 +887,8 @@
       "reference": "./CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": "71",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0",
+      "referenceNumber": "72",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
@@ -894,8 +899,8 @@
       "reference": "./CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": "72",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0",
+      "referenceNumber": "73",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
@@ -906,8 +911,8 @@
       "reference": "./CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": "73",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5",
+      "referenceNumber": "74",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
@@ -918,8 +923,8 @@
       "reference": "./CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": "74",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0",
+      "referenceNumber": "75",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
@@ -930,8 +935,8 @@
       "reference": "./CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": "75",
-      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0",
+      "referenceNumber": "76",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
@@ -942,8 +947,8 @@
       "reference": "./CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": "76",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0",
+      "referenceNumber": "77",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
@@ -954,8 +959,8 @@
       "reference": "./CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": "77",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0",
+      "referenceNumber": "78",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
@@ -966,8 +971,8 @@
       "reference": "./CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": "78",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5",
+      "referenceNumber": "79",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
@@ -978,8 +983,8 @@
       "reference": "./CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": "79",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0",
+      "referenceNumber": "80",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
@@ -990,8 +995,8 @@
       "reference": "./CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": "80",
-      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0",
+      "referenceNumber": "81",
+      "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
@@ -1001,10 +1006,9 @@
     {
       "reference": "./CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": "81",
-      "name": "Creative Commons Attribution No Derivatives 1.0",
+      "referenceNumber": "82",
+      "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nd/1.0/legalcode"
@@ -1014,10 +1018,9 @@
     {
       "reference": "./CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": "82",
-      "name": "Creative Commons Attribution No Derivatives 2.0",
+      "referenceNumber": "83",
+      "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
         "https://creativecommons.org/licenses/by-nd/2.0/legalcode"
@@ -1027,10 +1030,9 @@
     {
       "reference": "./CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": "83",
-      "name": "Creative Commons Attribution No Derivatives 2.5",
+      "referenceNumber": "84",
+      "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nd/2.5/legalcode"
@@ -1040,10 +1042,9 @@
     {
       "reference": "./CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": "84",
-      "name": "Creative Commons Attribution No Derivatives 3.0",
+      "referenceNumber": "85",
+      "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nd/3.0/legalcode"
@@ -1053,10 +1054,9 @@
     {
       "reference": "./CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": "85",
-      "name": "Creative Commons Attribution No Derivatives 4.0",
+      "referenceNumber": "86",
+      "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-nd/4.0/legalcode"
@@ -1067,8 +1067,8 @@
       "reference": "./CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": "86",
-      "name": "Creative Commons Attribution Share Alike 1.0",
+      "referenceNumber": "87",
+      "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-sa/1.0/legalcode"
@@ -1079,8 +1079,8 @@
       "reference": "./CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": "87",
-      "name": "Creative Commons Attribution Share Alike 2.0",
+      "referenceNumber": "88",
+      "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-sa/2.0/legalcode"
@@ -1091,8 +1091,8 @@
       "reference": "./CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": "88",
-      "name": "Creative Commons Attribution Share Alike 2.5",
+      "referenceNumber": "89",
+      "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-sa/2.5/legalcode"
@@ -1103,8 +1103,8 @@
       "reference": "./CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": "89",
-      "name": "Creative Commons Attribution Share Alike 3.0",
+      "referenceNumber": "90",
+      "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-sa/3.0/legalcode"
@@ -1116,8 +1116,8 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": "90",
-      "name": "Creative Commons Attribution Share Alike 4.0",
+      "referenceNumber": "91",
+      "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
         "http://creativecommons.org/licenses/by-sa/4.0/legalcode"
@@ -1129,7 +1129,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": "91",
+      "referenceNumber": "92",
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
@@ -1142,7 +1142,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": "92",
+      "referenceNumber": "93",
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
@@ -1154,7 +1154,7 @@
       "reference": "./CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": "93",
+      "referenceNumber": "94",
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -1167,7 +1167,7 @@
       "reference": "./CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": "94",
+      "referenceNumber": "95",
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -1179,7 +1179,7 @@
       "reference": "./CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": "95",
+      "referenceNumber": "96",
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -1191,7 +1191,7 @@
       "reference": "./CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": "96",
+      "referenceNumber": "97",
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -1203,7 +1203,7 @@
       "reference": "./CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": "97",
+      "referenceNumber": "98",
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -1216,7 +1216,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": "98",
+      "referenceNumber": "99",
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -1228,7 +1228,7 @@
       "reference": "./CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": "99",
+      "referenceNumber": "100",
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -1241,7 +1241,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": "100",
+      "referenceNumber": "101",
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -1254,7 +1254,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": "101",
+      "referenceNumber": "102",
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -1267,7 +1267,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": "102",
+      "referenceNumber": "103",
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -1280,7 +1280,7 @@
       "reference": "./CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": "103",
+      "referenceNumber": "104",
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -1292,7 +1292,7 @@
       "reference": "./CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": "104",
+      "referenceNumber": "105",
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -1304,7 +1304,7 @@
       "reference": "./CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": "105",
+      "referenceNumber": "106",
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
@@ -1317,7 +1317,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": "106",
+      "referenceNumber": "107",
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -1331,7 +1331,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": "107",
+      "referenceNumber": "108",
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
@@ -1344,7 +1344,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": "108",
+      "referenceNumber": "109",
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
@@ -1355,9 +1355,8 @@
     {
       "reference": "./CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": "109",
+      "referenceNumber": "110",
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -1369,7 +1368,7 @@
       "reference": "./Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Crossword.json",
-      "referenceNumber": "110",
+      "referenceNumber": "111",
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -1381,7 +1380,7 @@
       "reference": "./CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": "111",
+      "referenceNumber": "112",
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -1393,7 +1392,7 @@
       "reference": "./CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": "112",
+      "referenceNumber": "113",
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
@@ -1405,7 +1404,7 @@
       "reference": "./Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Cube.json",
-      "referenceNumber": "113",
+      "referenceNumber": "114",
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -1417,7 +1416,7 @@
       "reference": "./curl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/curl.json",
-      "referenceNumber": "114",
+      "referenceNumber": "115",
       "name": "curl License",
       "licenseId": "curl",
       "seeAlso": [
@@ -1429,7 +1428,7 @@
       "reference": "./D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": "115",
+      "referenceNumber": "116",
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -1448,7 +1447,7 @@
       "reference": "./diffmark.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/diffmark.json",
-      "referenceNumber": "116",
+      "referenceNumber": "117",
       "name": "diffmark license",
       "licenseId": "diffmark",
       "seeAlso": [
@@ -1460,7 +1459,7 @@
       "reference": "./DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DOC.json",
-      "referenceNumber": "117",
+      "referenceNumber": "118",
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -1472,7 +1471,7 @@
       "reference": "./Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": "118",
+      "referenceNumber": "119",
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -1484,7 +1483,7 @@
       "reference": "./DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DSDP.json",
-      "referenceNumber": "119",
+      "referenceNumber": "120",
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -1496,7 +1495,7 @@
       "reference": "./dvipdfm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": "120",
+      "referenceNumber": "121",
       "name": "dvipdfm License",
       "licenseId": "dvipdfm",
       "seeAlso": [
@@ -1508,7 +1507,7 @@
       "reference": "./ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": "121",
+      "referenceNumber": "122",
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
@@ -1521,7 +1520,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": "122",
+      "referenceNumber": "123",
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
@@ -1533,7 +1532,7 @@
       "reference": "./EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": "123",
+      "referenceNumber": "124",
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
@@ -1547,7 +1546,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": "124",
+      "referenceNumber": "125",
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
@@ -1560,7 +1559,7 @@
       "reference": "./eGenix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/eGenix.json",
-      "referenceNumber": "125",
+      "referenceNumber": "126",
       "name": "eGenix.com Public License 1.1.0",
       "licenseId": "eGenix",
       "seeAlso": [
@@ -1573,7 +1572,7 @@
       "reference": "./Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Entessa.json",
-      "referenceNumber": "126",
+      "referenceNumber": "127",
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
@@ -1586,7 +1585,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": "127",
+      "referenceNumber": "128",
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
@@ -1600,7 +1599,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": "128",
+      "referenceNumber": "129",
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
@@ -1613,7 +1612,7 @@
       "reference": "./ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": "129",
+      "referenceNumber": "130",
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -1626,7 +1625,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": "130",
+      "referenceNumber": "131",
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
@@ -1639,7 +1638,7 @@
       "reference": "./EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": "131",
+      "referenceNumber": "132",
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -1653,7 +1652,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": "132",
+      "referenceNumber": "133",
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
@@ -1667,7 +1666,7 @@
       "reference": "./EUPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": "133",
+      "referenceNumber": "134",
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -1683,7 +1682,7 @@
       "reference": "./Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": "134",
+      "referenceNumber": "135",
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -1695,12 +1694,12 @@
       "reference": "./Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Fair.json",
-      "referenceNumber": "135",
+      "referenceNumber": "136",
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Fair",
-        "http://fairlicense.org/"
+        "http://fairlicense.org/",
+        "http://www.opensource.org/licenses/Fair"
       ],
       "isOsiApproved": true
     },
@@ -1708,7 +1707,7 @@
       "reference": "./Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": "136",
+      "referenceNumber": "137",
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
@@ -1720,7 +1719,7 @@
       "reference": "./FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": "137",
+      "referenceNumber": "138",
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -1733,7 +1732,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": "138",
+      "referenceNumber": "139",
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
@@ -1745,7 +1744,7 @@
       "reference": "./FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": "139",
+      "referenceNumber": "140",
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -1757,7 +1756,7 @@
       "reference": "./FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": "140",
+      "referenceNumber": "141",
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -1770,7 +1769,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FTL.json",
-      "referenceNumber": "141",
+      "referenceNumber": "142",
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -1782,8 +1781,9 @@
     {
       "reference": "./GFDL-1.1-only.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": "142",
+      "referenceNumber": "143",
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
@@ -1794,8 +1794,9 @@
     {
       "reference": "./GFDL-1.1-or-later.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": "143",
+      "referenceNumber": "144",
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
@@ -1806,8 +1807,9 @@
     {
       "reference": "./GFDL-1.2-only.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": "144",
+      "referenceNumber": "145",
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
@@ -1818,8 +1820,9 @@
     {
       "reference": "./GFDL-1.2-or-later.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": "145",
+      "referenceNumber": "146",
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
@@ -1830,8 +1833,9 @@
     {
       "reference": "./GFDL-1.3-only.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": "146",
+      "referenceNumber": "147",
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
@@ -1842,8 +1846,9 @@
     {
       "reference": "./GFDL-1.3-or-later.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": "147",
+      "referenceNumber": "148",
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
@@ -1855,7 +1860,7 @@
       "reference": "./Giftware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Giftware.json",
-      "referenceNumber": "148",
+      "referenceNumber": "149",
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -1867,7 +1872,7 @@
       "reference": "./GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": "149",
+      "referenceNumber": "150",
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -1879,7 +1884,7 @@
       "reference": "./Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glide.json",
-      "referenceNumber": "150",
+      "referenceNumber": "151",
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -1891,7 +1896,7 @@
       "reference": "./Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": "151",
+      "referenceNumber": "152",
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -1904,7 +1909,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": "152",
+      "referenceNumber": "153",
       "name": "gnuplot License",
       "licenseId": "gnuplot",
       "seeAlso": [
@@ -1916,7 +1921,7 @@
       "reference": "./GPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": "153",
+      "referenceNumber": "154",
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0-only",
       "seeAlso": [
@@ -1928,7 +1933,7 @@
       "reference": "./GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": "154",
+      "referenceNumber": "155",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
@@ -1939,8 +1944,9 @@
     {
       "reference": "./GPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": "155",
+      "referenceNumber": "156",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
@@ -1952,8 +1958,9 @@
     {
       "reference": "./GPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": "156",
+      "referenceNumber": "157",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
@@ -1965,8 +1972,9 @@
     {
       "reference": "./GPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": "157",
+      "referenceNumber": "158",
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0-only",
       "seeAlso": [
@@ -1978,8 +1986,9 @@
     {
       "reference": "./GPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": "158",
+      "referenceNumber": "159",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
@@ -1992,7 +2001,7 @@
       "reference": "./gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": "159",
+      "referenceNumber": "160",
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "seeAlso": [
@@ -2004,7 +2013,7 @@
       "reference": "./HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": "160",
+      "referenceNumber": "161",
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -2017,7 +2026,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/HPND.json",
-      "referenceNumber": "161",
+      "referenceNumber": "162",
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "seeAlso": [
@@ -2029,7 +2038,7 @@
       "reference": "./IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": "162",
+      "referenceNumber": "163",
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -2041,7 +2050,7 @@
       "reference": "./ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ICU.json",
-      "referenceNumber": "163",
+      "referenceNumber": "164",
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -2054,7 +2063,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IJG.json",
-      "referenceNumber": "164",
+      "referenceNumber": "165",
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -2066,7 +2075,7 @@
       "reference": "./ImageMagick.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": "165",
+      "referenceNumber": "166",
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -2079,7 +2088,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/iMatix.json",
-      "referenceNumber": "166",
+      "referenceNumber": "167",
       "name": "iMatix Standard Function Library Agreement",
       "licenseId": "iMatix",
       "seeAlso": [
@@ -2092,7 +2101,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": "167",
+      "referenceNumber": "168",
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
@@ -2104,7 +2113,7 @@
       "reference": "./Info-ZIP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": "168",
+      "referenceNumber": "169",
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -2116,7 +2125,7 @@
       "reference": "./Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": "169",
+      "referenceNumber": "170",
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -2129,7 +2138,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Intel.json",
-      "referenceNumber": "170",
+      "referenceNumber": "171",
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
@@ -2141,7 +2150,7 @@
       "reference": "./Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": "171",
+      "referenceNumber": "172",
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -2154,7 +2163,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPA.json",
-      "referenceNumber": "172",
+      "referenceNumber": "173",
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
@@ -2167,7 +2176,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": "173",
+      "referenceNumber": "174",
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
@@ -2180,7 +2189,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ISC.json",
-      "referenceNumber": "174",
+      "referenceNumber": "175",
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
@@ -2193,7 +2202,7 @@
       "reference": "./JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": "175",
+      "referenceNumber": "176",
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -2204,9 +2213,8 @@
     {
       "reference": "./JSON.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/JSON.json",
-      "referenceNumber": "176",
+      "referenceNumber": "177",
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -2218,7 +2226,7 @@
       "reference": "./LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": "177",
+      "referenceNumber": "178",
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -2230,7 +2238,7 @@
       "reference": "./LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": "178",
+      "referenceNumber": "179",
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -2242,7 +2250,7 @@
       "reference": "./Latex2e.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": "179",
+      "referenceNumber": "180",
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -2254,7 +2262,7 @@
       "reference": "./Leptonica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": "180",
+      "referenceNumber": "181",
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -2266,7 +2274,7 @@
       "reference": "./LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": "181",
+      "referenceNumber": "182",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
@@ -2278,7 +2286,7 @@
       "reference": "./LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": "182",
+      "referenceNumber": "183",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
@@ -2289,8 +2297,9 @@
     {
       "reference": "./LGPL-2.1-only.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": "183",
+      "referenceNumber": "184",
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1-only",
       "seeAlso": [
@@ -2302,8 +2311,9 @@
     {
       "reference": "./LGPL-2.1-or-later.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": "184",
+      "referenceNumber": "185",
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
@@ -2315,8 +2325,9 @@
     {
       "reference": "./LGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": "185",
+      "referenceNumber": "186",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
@@ -2328,8 +2339,9 @@
     {
       "reference": "./LGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": "186",
+      "referenceNumber": "187",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
@@ -2342,7 +2354,7 @@
       "reference": "./LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": "187",
+      "referenceNumber": "188",
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -2354,7 +2366,7 @@
       "reference": "./Libpng.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Libpng.json",
-      "referenceNumber": "188",
+      "referenceNumber": "189",
       "name": "libpng License",
       "licenseId": "Libpng",
       "seeAlso": [
@@ -2366,7 +2378,7 @@
       "reference": "./libtiff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/libtiff.json",
-      "referenceNumber": "189",
+      "referenceNumber": "190",
       "name": "libtiff License",
       "licenseId": "libtiff",
       "seeAlso": [
@@ -2378,12 +2390,12 @@
       "reference": "./LiLiQ-P-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": "190",
+      "referenceNumber": "191",
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
-        "http://opensource.org/licenses/LiLiQ-P-1.1",
-        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/"
+        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-P-1.1"
       ],
       "isOsiApproved": true
     },
@@ -2391,12 +2403,12 @@
       "reference": "./LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": "191",
+      "referenceNumber": "192",
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
-        "http://opensource.org/licenses/LiLiQ-R-1.1",
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/"
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-R-1.1"
       ],
       "isOsiApproved": true
     },
@@ -2404,20 +2416,32 @@
       "reference": "./LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": "192",
+      "referenceNumber": "193",
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
-        "http://opensource.org/licenses/LiLiQ-Rplus-1.1",
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/"
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./Linux-OpenIB.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
+      "referenceNumber": "194",
+      "name": "Linux Kernel Variant of OpenIB.org license",
+      "licenseId": "Linux-OpenIB",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": "193",
+      "referenceNumber": "195",
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
@@ -2430,7 +2454,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": "194",
+      "referenceNumber": "196",
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
@@ -2443,7 +2467,7 @@
       "reference": "./LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": "195",
+      "referenceNumber": "197",
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -2455,7 +2479,7 @@
       "reference": "./LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": "196",
+      "referenceNumber": "198",
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -2468,7 +2492,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": "197",
+      "referenceNumber": "199",
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -2481,7 +2505,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": "198",
+      "referenceNumber": "200",
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -2493,7 +2517,7 @@
       "reference": "./LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": "199",
+      "referenceNumber": "201",
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
@@ -2506,7 +2530,7 @@
       "reference": "./MakeIndex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": "200",
+      "referenceNumber": "202",
       "name": "MakeIndex License",
       "licenseId": "MakeIndex",
       "seeAlso": [
@@ -2518,7 +2542,7 @@
       "reference": "./MirOS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MirOS.json",
-      "referenceNumber": "201",
+      "referenceNumber": "203",
       "name": "MirOS License",
       "licenseId": "MirOS",
       "seeAlso": [
@@ -2527,10 +2551,24 @@
       "isOsiApproved": true
     },
     {
+      "reference": "./MIT-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
+      "referenceNumber": "204",
+      "name": "MIT No Attribution",
+      "licenseId": "MIT-0",
+      "seeAlso": [
+        "https://github.com/aws/mit-0",
+        "https://romanrm.net/mit-zero",
+        "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./MIT-advertising.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": "202",
+      "referenceNumber": "205",
       "name": "Enlightenment License (e16)",
       "licenseId": "MIT-advertising",
       "seeAlso": [
@@ -2542,7 +2580,7 @@
       "reference": "./MIT-CMU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": "203",
+      "referenceNumber": "206",
       "name": "CMU License",
       "licenseId": "MIT-CMU",
       "seeAlso": [
@@ -2554,7 +2592,7 @@
       "reference": "./MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": "204",
+      "referenceNumber": "207",
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -2566,7 +2604,7 @@
       "reference": "./MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": "205",
+      "referenceNumber": "208",
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -2579,7 +2617,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MIT.json",
-      "referenceNumber": "206",
+      "referenceNumber": "209",
       "name": "MIT License",
       "licenseId": "MIT",
       "seeAlso": [
@@ -2591,7 +2629,7 @@
       "reference": "./MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": "207",
+      "referenceNumber": "210",
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -2603,7 +2641,7 @@
       "reference": "./Motosoto.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": "208",
+      "referenceNumber": "211",
       "name": "Motosoto License",
       "licenseId": "Motosoto",
       "seeAlso": [
@@ -2615,7 +2653,7 @@
       "reference": "./mpich2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/mpich2.json",
-      "referenceNumber": "209",
+      "referenceNumber": "212",
       "name": "mpich2 License",
       "licenseId": "mpich2",
       "seeAlso": [
@@ -2627,7 +2665,7 @@
       "reference": "./MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": "210",
+      "referenceNumber": "213",
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
@@ -2641,7 +2679,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": "211",
+      "referenceNumber": "214",
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
@@ -2654,7 +2692,7 @@
       "reference": "./MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": "212",
+      "referenceNumber": "215",
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
@@ -2668,7 +2706,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": "213",
+      "referenceNumber": "216",
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
@@ -2682,7 +2720,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": "214",
+      "referenceNumber": "217",
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
@@ -2696,7 +2734,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": "215",
+      "referenceNumber": "218",
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
@@ -2709,7 +2747,7 @@
       "reference": "./MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MTLL.json",
-      "referenceNumber": "216",
+      "referenceNumber": "219",
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -2721,7 +2759,7 @@
       "reference": "./Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Multics.json",
-      "referenceNumber": "217",
+      "referenceNumber": "220",
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
@@ -2733,7 +2771,7 @@
       "reference": "./Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Mup.json",
-      "referenceNumber": "218",
+      "referenceNumber": "221",
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -2744,9 +2782,8 @@
     {
       "reference": "./NASA-1.3.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": "219",
+      "referenceNumber": "222",
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
@@ -2759,7 +2796,7 @@
       "reference": "./Naumen.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Naumen.json",
-      "referenceNumber": "220",
+      "referenceNumber": "223",
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
@@ -2771,7 +2808,7 @@
       "reference": "./NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": "221",
+      "referenceNumber": "224",
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -2784,7 +2821,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NCSA.json",
-      "referenceNumber": "222",
+      "referenceNumber": "225",
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
@@ -2797,7 +2834,7 @@
       "reference": "./Net-SNMP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": "223",
+      "referenceNumber": "226",
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -2809,7 +2846,7 @@
       "reference": "./NetCDF.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": "224",
+      "referenceNumber": "227",
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -2821,7 +2858,7 @@
       "reference": "./Newsletr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": "225",
+      "referenceNumber": "228",
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -2833,7 +2870,7 @@
       "reference": "./NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NGPL.json",
-      "referenceNumber": "226",
+      "referenceNumber": "229",
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
@@ -2845,7 +2882,7 @@
       "reference": "./NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": "227",
+      "referenceNumber": "230",
       "name": "Norwegian Licence for Open Government Data",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -2857,7 +2894,7 @@
       "reference": "./NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLPL.json",
-      "referenceNumber": "228",
+      "referenceNumber": "231",
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -2870,7 +2907,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nokia.json",
-      "referenceNumber": "229",
+      "referenceNumber": "232",
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
@@ -2883,7 +2920,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NOSL.json",
-      "referenceNumber": "230",
+      "referenceNumber": "233",
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -2895,7 +2932,7 @@
       "reference": "./Noweb.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Noweb.json",
-      "referenceNumber": "231",
+      "referenceNumber": "234",
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -2908,7 +2945,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": "232",
+      "referenceNumber": "235",
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -2921,7 +2958,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": "233",
+      "referenceNumber": "236",
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -2933,7 +2970,7 @@
       "reference": "./NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": "234",
+      "referenceNumber": "237",
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
@@ -2945,7 +2982,7 @@
       "reference": "./NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NRL.json",
-      "referenceNumber": "235",
+      "referenceNumber": "238",
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -2957,7 +2994,7 @@
       "reference": "./NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NTP.json",
-      "referenceNumber": "236",
+      "referenceNumber": "239",
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
@@ -2969,7 +3006,7 @@
       "reference": "./OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": "237",
+      "referenceNumber": "240",
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -2981,7 +3018,7 @@
       "reference": "./OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": "238",
+      "referenceNumber": "241",
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
@@ -2995,7 +3032,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": "239",
+      "referenceNumber": "242",
       "name": "ODC Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
@@ -3007,7 +3044,7 @@
       "reference": "./OFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": "240",
+      "referenceNumber": "243",
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "seeAlso": [
@@ -3020,7 +3057,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": "241",
+      "referenceNumber": "244",
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
@@ -3033,7 +3070,7 @@
       "reference": "./OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": "242",
+      "referenceNumber": "245",
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
@@ -3046,7 +3083,7 @@
       "reference": "./OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": "243",
+      "referenceNumber": "246",
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -3058,7 +3095,7 @@
       "reference": "./OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": "244",
+      "referenceNumber": "247",
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -3070,7 +3107,7 @@
       "reference": "./OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": "245",
+      "referenceNumber": "248",
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -3082,7 +3119,7 @@
       "reference": "./OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": "246",
+      "referenceNumber": "249",
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -3094,7 +3131,7 @@
       "reference": "./OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": "247",
+      "referenceNumber": "250",
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -3106,7 +3143,7 @@
       "reference": "./OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": "248",
+      "referenceNumber": "251",
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -3118,7 +3155,7 @@
       "reference": "./OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": "249",
+      "referenceNumber": "252",
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -3130,7 +3167,7 @@
       "reference": "./OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": "250",
+      "referenceNumber": "253",
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -3142,7 +3179,7 @@
       "reference": "./OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": "251",
+      "referenceNumber": "254",
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -3154,7 +3191,7 @@
       "reference": "./OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": "252",
+      "referenceNumber": "255",
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -3167,7 +3204,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": "253",
+      "referenceNumber": "256",
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -3179,7 +3216,7 @@
       "reference": "./OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": "254",
+      "referenceNumber": "257",
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -3191,7 +3228,7 @@
       "reference": "./OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": "255",
+      "referenceNumber": "258",
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -3203,7 +3240,7 @@
       "reference": "./OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": "256",
+      "referenceNumber": "259",
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -3216,7 +3253,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": "257",
+      "referenceNumber": "260",
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -3228,7 +3265,7 @@
       "reference": "./OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": "258",
+      "referenceNumber": "261",
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
@@ -3240,7 +3277,7 @@
       "reference": "./OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OML.json",
-      "referenceNumber": "259",
+      "referenceNumber": "262",
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -3253,7 +3290,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": "260",
+      "referenceNumber": "263",
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -3264,9 +3301,8 @@
     {
       "reference": "./OPL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": "261",
+      "referenceNumber": "264",
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -3279,12 +3315,12 @@
       "reference": "./OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": "262",
+      "referenceNumber": "265",
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
-        "http://opensource.org/licenses/OPL-2.1",
-        "http://www.osetfoundation.org/public-license"
+        "http://www.osetfoundation.org/public-license",
+        "http://opensource.org/licenses/OPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -3293,7 +3329,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": "263",
+      "referenceNumber": "266",
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
@@ -3306,7 +3342,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": "264",
+      "referenceNumber": "267",
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -3319,7 +3355,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": "265",
+      "referenceNumber": "268",
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -3332,12 +3368,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": "266",
+      "referenceNumber": "269",
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
-        "http://opensource.org/licenses/OSL-2.1",
-        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm"
+        "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
+        "http://opensource.org/licenses/OSL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -3346,7 +3382,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": "267",
+      "referenceNumber": "270",
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
@@ -3359,7 +3395,7 @@
       "reference": "./PDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": "268",
+      "referenceNumber": "271",
       "name": "ODC Public Domain Dedication \u0026 License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
@@ -3371,12 +3407,12 @@
       "reference": "./PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": "269",
+      "referenceNumber": "272",
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/PHP-3.0",
-        "http://www.php.net/license/3_0.txt"
+        "http://www.php.net/license/3_0.txt",
+        "http://www.opensource.org/licenses/PHP-3.0"
       ],
       "isOsiApproved": true
     },
@@ -3385,7 +3421,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": "270",
+      "referenceNumber": "273",
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
@@ -3397,7 +3433,7 @@
       "reference": "./Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Plexus.json",
-      "referenceNumber": "271",
+      "referenceNumber": "274",
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -3409,7 +3445,7 @@
       "reference": "./PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": "272",
+      "referenceNumber": "275",
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
@@ -3422,7 +3458,7 @@
       "reference": "./psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/psfrag.json",
-      "referenceNumber": "273",
+      "referenceNumber": "276",
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -3434,7 +3470,7 @@
       "reference": "./psutils.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/psutils.json",
-      "referenceNumber": "274",
+      "referenceNumber": "277",
       "name": "psutils License",
       "licenseId": "psutils",
       "seeAlso": [
@@ -3447,7 +3483,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": "275",
+      "referenceNumber": "278",
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
@@ -3459,7 +3495,7 @@
       "reference": "./Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Qhull.json",
-      "referenceNumber": "276",
+      "referenceNumber": "279",
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -3472,7 +3508,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": "277",
+      "referenceNumber": "280",
       "name": "Q Public License 1.0",
       "licenseId": "QPL-1.0",
       "seeAlso": [
@@ -3485,7 +3521,7 @@
       "reference": "./Rdisc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": "278",
+      "referenceNumber": "281",
       "name": "Rdisc License",
       "licenseId": "Rdisc",
       "seeAlso": [
@@ -3496,9 +3532,8 @@
     {
       "reference": "./RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": "279",
+      "referenceNumber": "282",
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -3510,7 +3545,7 @@
       "reference": "./RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": "280",
+      "referenceNumber": "283",
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
@@ -3522,7 +3557,7 @@
       "reference": "./RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": "281",
+      "referenceNumber": "284",
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
@@ -3535,7 +3570,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": "282",
+      "referenceNumber": "285",
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
@@ -3548,7 +3583,7 @@
       "reference": "./RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": "283",
+      "referenceNumber": "286",
       "name": "RSA Message-Digest License ",
       "licenseId": "RSA-MD",
       "seeAlso": [
@@ -3560,12 +3595,12 @@
       "reference": "./RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": "284",
+      "referenceNumber": "287",
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
-        "http://www.opensource.org/licenses/RSCPL",
-        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml"
+        "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
+        "http://www.opensource.org/licenses/RSCPL"
       ],
       "isOsiApproved": true
     },
@@ -3574,7 +3609,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Ruby.json",
-      "referenceNumber": "285",
+      "referenceNumber": "288",
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -3586,7 +3621,7 @@
       "reference": "./SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": "286",
+      "referenceNumber": "289",
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -3598,7 +3633,7 @@
       "reference": "./Saxpath.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": "287",
+      "referenceNumber": "290",
       "name": "Saxpath License",
       "licenseId": "Saxpath",
       "seeAlso": [
@@ -3610,7 +3645,7 @@
       "reference": "./SCEA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SCEA.json",
-      "referenceNumber": "288",
+      "referenceNumber": "291",
       "name": "SCEA Shared Source License",
       "licenseId": "SCEA",
       "seeAlso": [
@@ -3622,7 +3657,7 @@
       "reference": "./Sendmail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": "289",
+      "referenceNumber": "292",
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -3635,7 +3670,7 @@
       "reference": "./SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": "290",
+      "referenceNumber": "293",
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -3647,7 +3682,7 @@
       "reference": "./SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": "291",
+      "referenceNumber": "294",
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -3660,7 +3695,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": "292",
+      "referenceNumber": "295",
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -3672,7 +3707,7 @@
       "reference": "./SimPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": "293",
+      "referenceNumber": "296",
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
@@ -3684,7 +3719,7 @@
       "reference": "./SISSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": "294",
+      "referenceNumber": "297",
       "name": "Sun Industry Standards Source License v1.2",
       "licenseId": "SISSL-1.2",
       "seeAlso": [
@@ -3695,8 +3730,9 @@
     {
       "reference": "./SISSL.html",
       "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SISSL.json",
-      "referenceNumber": "295",
+      "referenceNumber": "298",
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
@@ -3710,7 +3746,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": "296",
+      "referenceNumber": "299",
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
@@ -3723,7 +3759,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": "297",
+      "referenceNumber": "300",
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -3735,7 +3771,7 @@
       "reference": "./SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": "298",
+      "referenceNumber": "301",
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -3747,7 +3783,7 @@
       "reference": "./SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SNIA.json",
-      "referenceNumber": "299",
+      "referenceNumber": "302",
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -3759,7 +3795,7 @@
       "reference": "./Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": "300",
+      "referenceNumber": "303",
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -3771,7 +3807,7 @@
       "reference": "./Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": "301",
+      "referenceNumber": "304",
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -3783,7 +3819,7 @@
       "reference": "./Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": "302",
+      "referenceNumber": "305",
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -3796,7 +3832,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": "303",
+      "referenceNumber": "306",
       "name": "Sun Public License v1.0",
       "licenseId": "SPL-1.0",
       "seeAlso": [
@@ -3808,7 +3844,7 @@
       "reference": "./SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": "304",
+      "referenceNumber": "307",
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -3820,7 +3856,7 @@
       "reference": "./SWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SWL.json",
-      "referenceNumber": "305",
+      "referenceNumber": "308",
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "seeAlso": [
@@ -3832,7 +3868,7 @@
       "reference": "./TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCL.json",
-      "referenceNumber": "306",
+      "referenceNumber": "309",
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -3845,7 +3881,7 @@
       "reference": "./TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": "307",
+      "referenceNumber": "310",
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -3857,7 +3893,7 @@
       "reference": "./TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TMate.json",
-      "referenceNumber": "308",
+      "referenceNumber": "311",
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -3869,7 +3905,7 @@
       "reference": "./TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": "309",
+      "referenceNumber": "312",
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -3881,7 +3917,7 @@
       "reference": "./TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TOSL.json",
-      "referenceNumber": "310",
+      "referenceNumber": "313",
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -3893,7 +3929,7 @@
       "reference": "./Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": "311",
+      "referenceNumber": "314",
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -3905,7 +3941,7 @@
       "reference": "./Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": "312",
+      "referenceNumber": "315",
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
@@ -3917,7 +3953,7 @@
       "reference": "./Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": "313",
+      "referenceNumber": "316",
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -3930,7 +3966,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": "314",
+      "referenceNumber": "317",
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
@@ -3943,7 +3979,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": "315",
+      "referenceNumber": "318",
       "name": "Universal Permissive License v1.0",
       "licenseId": "UPL-1.0",
       "seeAlso": [
@@ -3956,7 +3992,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Vim.json",
-      "referenceNumber": "316",
+      "referenceNumber": "319",
       "name": "Vim License",
       "licenseId": "Vim",
       "seeAlso": [
@@ -3968,7 +4004,7 @@
       "reference": "./VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": "317",
+      "referenceNumber": "320",
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -3980,7 +4016,7 @@
       "reference": "./VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": "318",
+      "referenceNumber": "321",
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
@@ -3992,7 +4028,7 @@
       "reference": "./W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": "319",
+      "referenceNumber": "322",
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -4004,7 +4040,7 @@
       "reference": "./W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": "320",
+      "referenceNumber": "323",
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -4017,7 +4053,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/W3C.json",
-      "referenceNumber": "321",
+      "referenceNumber": "324",
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
@@ -4029,9 +4065,8 @@
     {
       "reference": "./Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": "322",
+      "referenceNumber": "325",
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
@@ -4043,7 +4078,7 @@
       "reference": "./Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": "323",
+      "referenceNumber": "326",
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -4056,7 +4091,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": "324",
+      "referenceNumber": "327",
       "name": "Do What The F*ck You Want To Public License",
       "licenseId": "WTFPL",
       "seeAlso": [
@@ -4069,7 +4104,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/X11.json",
-      "referenceNumber": "325",
+      "referenceNumber": "328",
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -4081,7 +4116,7 @@
       "reference": "./Xerox.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Xerox.json",
-      "referenceNumber": "326",
+      "referenceNumber": "329",
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -4094,7 +4129,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": "327",
+      "referenceNumber": "330",
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -4107,7 +4142,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/xinetd.json",
-      "referenceNumber": "328",
+      "referenceNumber": "331",
       "name": "xinetd License",
       "licenseId": "xinetd",
       "seeAlso": [
@@ -4119,7 +4154,7 @@
       "reference": "./Xnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Xnet.json",
-      "referenceNumber": "329",
+      "referenceNumber": "332",
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
@@ -4131,7 +4166,7 @@
       "reference": "./xpp.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/xpp.json",
-      "referenceNumber": "330",
+      "referenceNumber": "333",
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -4143,7 +4178,7 @@
       "reference": "./XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/XSkat.json",
-      "referenceNumber": "331",
+      "referenceNumber": "334",
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -4155,7 +4190,7 @@
       "reference": "./YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": "332",
+      "referenceNumber": "335",
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -4168,7 +4203,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": "333",
+      "referenceNumber": "336",
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -4180,7 +4215,7 @@
       "reference": "./Zed.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Zed.json",
-      "referenceNumber": "334",
+      "referenceNumber": "337",
       "name": "Zed License",
       "licenseId": "Zed",
       "seeAlso": [
@@ -4193,7 +4228,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": "335",
+      "referenceNumber": "338",
       "name": "Zend License v2.0",
       "licenseId": "Zend-2.0",
       "seeAlso": [
@@ -4206,16 +4241,19 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": "336",
+      "referenceNumber": "339",
       "name": "Zimbra Public License v1.3",
       "licenseId": "Zimbra-1.3",
+      "seeAlso": [
+        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ],
       "isOsiApproved": false
     },
     {
       "reference": "./Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": "337",
+      "referenceNumber": "340",
       "name": "Zimbra Public License v1.4",
       "licenseId": "Zimbra-1.4",
       "seeAlso": [
@@ -4227,7 +4265,7 @@
       "reference": "./zlib-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": "338",
+      "referenceNumber": "341",
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
@@ -4240,7 +4278,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Zlib.json",
-      "referenceNumber": "339",
+      "referenceNumber": "342",
       "name": "zlib License",
       "licenseId": "Zlib",
       "seeAlso": [
@@ -4253,7 +4291,7 @@
       "reference": "./ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": "340",
+      "referenceNumber": "343",
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -4266,7 +4304,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": "341",
+      "referenceNumber": "344",
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
@@ -4280,7 +4318,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": "342",
+      "referenceNumber": "345",
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -4289,11 +4327,24 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./AGPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
+      "referenceNumber": "346",
+      "name": "Affero General Public License v1.0",
+      "licenseId": "AGPL-1.0",
+      "seeAlso": [
+        "http://www.affero.org/oagpl.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./AGPL-3.0.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": "343",
+      "referenceNumber": "347",
       "name": "GNU Affero General Public License v3.0",
       "licenseId": "AGPL-3.0",
       "seeAlso": [
@@ -4305,9 +4356,9 @@
     {
       "reference": "./eCos-2.0.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": "344",
+      "referenceNumber": "348",
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -4318,9 +4369,9 @@
     {
       "reference": "./GFDL-1.1.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": "345",
+      "referenceNumber": "349",
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
       "seeAlso": [
@@ -4331,9 +4382,9 @@
     {
       "reference": "./GFDL-1.2.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": "346",
+      "referenceNumber": "350",
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
       "seeAlso": [
@@ -4344,9 +4395,9 @@
     {
       "reference": "./GFDL-1.3.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": "347",
+      "referenceNumber": "351",
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
       "seeAlso": [
@@ -4357,9 +4408,8 @@
     {
       "reference": "./GPL-1.0+.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": "348",
+      "referenceNumber": "352",
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0+",
       "seeAlso": [
@@ -4370,9 +4420,8 @@
     {
       "reference": "./GPL-1.0.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": "349",
+      "referenceNumber": "353",
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0",
       "seeAlso": [
@@ -4383,9 +4432,9 @@
     {
       "reference": "./GPL-2.0+.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": "350",
+      "referenceNumber": "354",
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0+",
       "seeAlso": [
@@ -4397,9 +4446,8 @@
     {
       "reference": "./GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": "351",
+      "referenceNumber": "355",
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -4410,9 +4458,8 @@
     {
       "reference": "./GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": "352",
+      "referenceNumber": "356",
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -4423,9 +4470,8 @@
     {
       "reference": "./GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": "353",
+      "referenceNumber": "357",
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
@@ -4436,9 +4482,8 @@
     {
       "reference": "./GPL-2.0-with-font-exception.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": "354",
+      "referenceNumber": "358",
       "name": "GNU General Public License v2.0 w/Font exception",
       "licenseId": "GPL-2.0-with-font-exception",
       "seeAlso": [
@@ -4449,9 +4494,8 @@
     {
       "reference": "./GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": "355",
+      "referenceNumber": "359",
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -4462,9 +4506,9 @@
     {
       "reference": "./GPL-2.0.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": "356",
+      "referenceNumber": "360",
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0",
       "seeAlso": [
@@ -4476,9 +4520,9 @@
     {
       "reference": "./GPL-3.0+.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": "357",
+      "referenceNumber": "361",
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
       "seeAlso": [
@@ -4490,9 +4534,8 @@
     {
       "reference": "./GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": "358",
+      "referenceNumber": "362",
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
@@ -4503,9 +4546,8 @@
     {
       "reference": "./GPL-3.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": "359",
+      "referenceNumber": "363",
       "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-3.0-with-GCC-exception",
       "seeAlso": [
@@ -4516,9 +4558,9 @@
     {
       "reference": "./GPL-3.0.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": "360",
+      "referenceNumber": "364",
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0",
       "seeAlso": [
@@ -4530,9 +4572,8 @@
     {
       "reference": "./LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": "361",
+      "referenceNumber": "365",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0+",
       "seeAlso": [
@@ -4543,9 +4584,8 @@
     {
       "reference": "./LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": "362",
+      "referenceNumber": "366",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
@@ -4556,10 +4596,10 @@
     {
       "reference": "./LGPL-2.1+.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": "363",
-      "name": "GNU Library General Public License v2 or later",
+      "referenceNumber": "367",
+      "name": "GNU Library General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
         "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
@@ -4570,9 +4610,9 @@
     {
       "reference": "./LGPL-2.1.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": "364",
+      "referenceNumber": "368",
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
@@ -4584,9 +4624,9 @@
     {
       "reference": "./LGPL-3.0+.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": "365",
+      "referenceNumber": "369",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0+",
       "seeAlso": [
@@ -4598,9 +4638,9 @@
     {
       "reference": "./LGPL-3.0.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": "366",
+      "referenceNumber": "370",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
@@ -4612,9 +4652,9 @@
     {
       "reference": "./Nunit.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Nunit.json",
-      "referenceNumber": "367",
+      "referenceNumber": "371",
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -4625,9 +4665,9 @@
     {
       "reference": "./StandardML-NJ.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
+      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": "368",
+      "referenceNumber": "372",
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -4638,9 +4678,8 @@
     {
       "reference": "./wxWindows.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": false,
       "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": "369",
+      "referenceNumber": "373",
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
@@ -4649,5 +4688,5 @@
       "isOsiApproved": false
     }
   ],
-  "releaseDate": "28 December 2017"
+  "releaseDate": "2018-04-14"
 }

--- a/lib/license_scout/license.rb
+++ b/lib/license_scout/license.rb
@@ -107,7 +107,7 @@ module LicenseScout
         begin
           LicenseScout::Log.debug("[license] Pulling license content for #{license_id} from #{new_url}")
           open(new_url).read
-        rescue OpenURI::HTTPError
+        rescue OpenURI::HTTPError, Errno::ECONNREFUSED
           LicenseScout::Log.warn("[license] Unable to download license for #{license_id} from #{new_url}")
           nil
         rescue RuntimeError => e

--- a/lib/license_scout/spdx.rb
+++ b/lib/license_scout/spdx.rb
@@ -31,7 +31,7 @@ module LicenseScout
       #   license_id was nil, or nil if we could not find a valid SPDX ID
       def find(license_id, force = false)
         return license_id if force
-        return nil if license_id.nil?
+        return nil if license_id.nil? || %w{ NOASSERTION NONE }.include?(license_id)
         lookup(license_id) || find_by_special_case(license_id) || closest(license_id) || license_id
       end
 


### PR DESCRIPTION
* Gracefully handle Errno::ECONNREFUSED when downloading licenses
* Update SPDX definitions to 3.1
* Update Licensee - treat `NOASSERTION` and `NONE` responses as missing licenses