### PR TITLE
add buffer-alloc, buffer-alloc-unsafe, and buffer-fill

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -33,5 +33,5 @@ merge_actions:
 
 promote:
   action:
-    - built_in:publish_rubygems
     - built_in:rollover_changelog
+    - built_in:publish_rubygems

--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -880,6 +880,9 @@ module LicenseScout
         # jszip says it is dual licensed under MIT and GPLv3
         ["jszip", "MIT", ["https://raw.githubusercontent.com/Stuk/jszip/master/LICENSE.markdown"]],
         ["buffer-from", "MIT", ["https://raw.githubusercontent.com/LinusU/buffer-from/master/LICENSE"]],
+        ["buffer-alloc", nil, [canonical("MIT")]],
+        ["buffer-alloc-unsafe", nil, [canonical("MIT")]],
+        ["buffer-fill", nil, [canonical("MIT")]]
       ].each do |override_data|
         override_license "js_npm", override_data[0] do |version|
           {}.tap do |d|


### PR DESCRIPTION
Also fixes the license scout action order.