### PR TITLE
Add channel_for_origin Habitat configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,22 @@ license_content | A URL to a file where the raw text of the license can be downl
 
 In addition to including any files Licensee identified as potential license files (but couldn't identify), License Scout will also include the Fallback License you specified in the Dependency Manifest.
 
+## Habitat Channel Configuration
+
+By default License Scout searches for Habitat package in the `stable`
+channel. If your build process publishes packages to another channel
+by default, you can use the `channel_for_origin` habitat configuration
+option:
+
+```yaml
+habitat:
+  channel_for_origin:
+    - origin: yourorigin
+      channel: dev
+    - origin: someotherorigin
+      channel: prod
+```
+
 ## Exporting a Dependency Manifest to another format
 
 By default, License Scout creates the Dependency Manifest as a JSON file. We do this because it provides a single document that can be easily processed into many different forms. License Scout has the ability to also export that JSON file into other formats.
@@ -223,4 +239,3 @@ Pull requests in this project are merged when they have two :+1:s from maintaine
 
 - [Dan DeLeo](https://github.com/danielsdeleo)
 - [Tom Duffield](https://github.com/tduffield)
-

--- a/lib/license_scout/config.rb
+++ b/lib/license_scout/config.rb
@@ -62,6 +62,10 @@ module LicenseScout
       default :ruby, []
     end
 
+    config_context :habitat do
+      default :channel_for_origin, []
+    end
+
     # Runtime Parameters - if you add any bins, make sure to update the habitat/plan.sh
     # to ensure we override the defaults to scope to the Habitat path
     default :environment, {}

--- a/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Habitat/_dependencies/when_an_channel_for_origin_is_used/returns_an_array_of_Dependencies_found_in_the_directory.yml
+++ b/spec/fixtures/vcr_cassettes/LicenseScout_DependencyManager_Habitat/_dependencies/when_an_channel_for_origin_is_used/returns_an_array_of_Dependencies_found_in_the_directory.yml
@@ -1,0 +1,827 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bldr.habitat.sh/v1/depot/channels/core/unstable/pkgs/glibc/latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, range
+      Access-Control-Allow-Methods:
+      - PUT, DELETE, PATCH
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - content-disposition
+      Cache-Control:
+      - private, no-cache, no-store, private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - nginx/1.13.10
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - '0'
+      - '0'
+      - '0'
+      - '0'
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Content-Length:
+      - '6591'
+      Date:
+      - Thu, 23 Aug 2018 10:23:35 GMT
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sea1030-SEA, cache-lhr6333-LHR
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age= 7776000; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"channels":["base-plans-2018-06","stable","unstable"],"checksum":"953093152ce8208332cebcb87e625069a68486ce502874792e9867e6ef7ae6f0","config":"","deps":[{"name":"linux-headers","origin":"core","release":"20180608041107","version":"4.15.9"}],"exposes":[],"ident":{"name":"glibc","origin":"core","release":"20180608041157","version":"2.27"},"is_a_service":false,"manifest":"#
+        core / glibc\nThe GNU C Library project provides the core libraries for the
+        GNU system and GNU/Linux systems, as well as many other systems that use Linux
+        as the kernel. These libraries provide critical APIs including ISO C11, POSIX.1-2008,
+        BSD, OS-specific APIs and more. These APIs include such foundational facilities
+        as open, read, write, malloc, printf, getaddrinfo, dlopen, pthread_create,
+        crypt, login, exit and more.\n\n* __Maintainer__: The Habitat Maintainers
+        <humans@habitat.sh>\n* __Version__: 2.27\n* __Release__: 20180608041157\n*
+        __Architecture__: x86_64\n* __System__: linux\n* __Target__: x86_64-linux\n*
+        __Upstream URL__: [https://www.gnu.org/software/libc](https://www.gnu.org/software/libc)\n*
+        __License__: GPL-2.0 LGPL-2.0 \n* __Source__: [http://ftp.gnu.org/gnu/glibc/glibc-2.27.tar.xz](http://ftp.gnu.org/gnu/glibc/glibc-2.27.tar.xz)\n*
+        __SHA__: `5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72`\n*
+        __Path__: `/hab/pkgs/core/glibc/2.27/20180608041157`\n* __Build Dependencies__:
+        `core/coreutils core/bison core/diffutils core/patch core/make core/gcc core/sed
+        core/perl `\n* __Dependencies__: `core/linux-headers `\n* __Interpreters__:
+        no interpreters or undefined\n\n# Plan\n\n## Build Flags\n\n```bash\nCFLAGS:
+        no CFLAGS\nCPPFLAGS: -I/hab/pkgs/core/linux-headers/4.15.9/20180608041107/include
+        -I/hab/pkgs/core/make/4.2.1/20180608031320/include -I/hab/pkgs/core/gcc/7.3.0/20180607201502/include\nCXXFLAGS:
+        -I/hab/pkgs/core/linux-headers/4.15.9/20180608041107/include -I/hab/pkgs/core/make/4.2.1/20180608031320/include
+        -I/hab/pkgs/core/gcc/7.3.0/20180607201502/include\nLDFLAGS: -Wl,--dynamic-linker=/hab/pkgs/core/glibc/2.27/20180608041157/lib/ld-linux-x86-64.so.2\nLD_RUN_PATH:
+        no LD_RUN_PATH\n```\n\n## Plan Source\n\n```bash\npkg_name=glibc\npkg_origin=core\npkg_version=2.27\npkg_maintainer=\"The
+        Habitat Maintainers <humans@habitat.sh>\"\npkg_description=\"\\\nThe GNU C
+        Library project provides the core libraries for the GNU system and \\\nGNU/Linux
+        systems, as well as many other systems that use Linux as the \\\nkernel. These
+        libraries provide critical APIs including ISO C11, \\\nPOSIX.1-2008, BSD,
+        OS-specific APIs and more. These APIs include such \\\nfoundational facilities
+        as open, read, write, malloc, printf, getaddrinfo, \\\ndlopen, pthread_create,
+        crypt, login, exit and more.\\\n\"\npkg_upstream_url=\"https://www.gnu.org/software/libc\"\npkg_license=(''GPL-2.0''
+        ''LGPL-2.0'')\npkg_source=\"http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz\"\npkg_shasum=\"5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72\"\npkg_deps=(\n  core/linux-headers\n)\npkg_build_deps=(\n  core/coreutils\n  core/bison\n  core/diffutils\n  core/patch\n  core/make\n  core/gcc\n  core/sed\n  core/perl\n)\npkg_bin_dirs=(bin)\npkg_include_dirs=(include)\npkg_lib_dirs=(lib)\n\ndo_prepare()
+        {\n  # The `/bin/pwd` path is hardcoded, so we''ll add a symlink if needed.\n  if
+        [[ ! -r /bin/pwd ]]; then\n    # We can''t use the `command -v pwd` trick
+        here, as `pwd` is a shell\n    # builtin, and therefore returns the string
+        of \"pwd\" (i.e. not the full\n    # path to the executable on `$PATH`). In
+        a stage1 Studio, the coreutils\n    # package isn''t built yet so we can''t
+        rely on using the `pkg_path_for`\n    # helper either.  Sweet twist, no?\n    if
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n      ln -sv /tools/bin/pwd /bin/pwd\n    else\n      ln
+        -sv \"$(pkg_path_for coreutils)/bin/pwd\" /bin/pwd\n    fi\n    _clean_pwd=true\n  fi\n\n  #
+        Determine the full path to the linker which will be produced.\n  dynamic_linker=\"$pkg_prefix/lib/ld-linux-x86-64.so.2\"\n\n  #
+        We don''t want glibc to try and reference itself before it''s installed,\n  #
+        no `$LD_RUN_PATH`s here\n  unset LD_RUN_PATH\n  build_line \"Overriding LD_RUN_PATH=$LD_RUN_PATH\"\n\n  unset
+        CFLAGS\n  build_line \"Overriding CFLAGS=$CFLAGS\"\n\n  # Add a dynamic-linker
+        option to `$LDFLAGS` so that every dynamic ELF binary\n  # will use our own
+        dynamic linker and not a previously built version.\n  LDFLAGS=\"-Wl,--dynamic-linker=$dynamic_linker\"\n  build_line
+        \"Setting LDFLAGS=$LDFLAGS\"\n\n  # Don''t depend on dynamically linked libgcc
+        for nscd, as we don''t want it\n  # depending on any bootstrapped version.\n  echo
+        \"LDFLAGS-nscd += -static-libgcc\" >> nscd/Makefile\n\n  # Have `rpcgen(1)`
+        look for `cpp(1)` in `$PATH`.\n  # Thanks to https://github.com/NixOS/nixpkgs/blob/1b55b07/pkgs/development/libraries/glibc/rpcgen-path.patch\n  patch
+        -p1 < \"$PLAN_CONTEXT/rpcgen-path.patch\"\n\n  # Don''t use the system''s
+        `/etc/ld.so.cache` and `/etc/ld.so.preload`, but\n  # rather the version under
+        `$pkg_prefix/etc`.\n  #\n  # Thanks to https://github.com/NixOS/nixpkgs/blob/54fc2db/pkgs/development/libraries/glibc/dont-use-system-ld-so-cache.patch\n  #
+        and to https://github.com/NixOS/nixpkgs/blob/dac591a/pkgs/development/libraries/glibc/dont-use-system-ld-so-preload.patch\n  #
+        shellcheck disable=SC2002\n  cat \"$PLAN_CONTEXT/dont-use-system-ld-so.patch\"
+        \\\n    | sed \"s,@prefix@,$pkg_prefix,g\" \\\n    | patch -p1\n\n  # Fix
+        for the scanf15 and scanf17 tests for arches that need\n  # misc/bits/syscall.h.
+        This problem is present once a custom location is used\n  # for the Linux
+        Kernel headers.\n  #\n  # Source: https://lists.debian.org/debian-glibc/2013/11/msg00116.html\n  patch
+        -p1 < \"$PLAN_CONTEXT/testsuite-fix.patch\"\n\n  # Adjust `scripts/test-installation.pl`
+        to use our new dynamic linker\n  sed -i \"s|libs -o|libs -L${pkg_prefix}/lib
+        -Wl,-dynamic-linker=${dynamic_linker} -o|\" \\\n    scripts/test-installation.pl\n}\n\ndo_build()
+        {\n  rm -rf ../${pkg_name}-build\n  mkdir ../${pkg_name}-build\n  pushd ../${pkg_name}-build
+        > /dev/null\n    # Configure Glibc to install its libraries into `$pkg_prefix/lib`\n    echo
+        \"libc_cv_slibdir=$pkg_prefix/lib\" >> config.cache\n    echo \"libc_cv_ssp=no\"
+        >> config.cache\n\n    \"../$pkg_dirname/configure\" \\\n      --prefix=\"$pkg_prefix\"
+        \\\n      --sbindir=\"$pkg_prefix/bin\" \\\n      --with-headers=\"$(pkg_path_for
+        linux-headers)/include\" \\\n      --libdir=\"$pkg_prefix/lib\" \\\n      --libexecdir=\"$pkg_prefix/lib/glibc\"
+        \\\n      --sysconfdir=\"$pkg_prefix/etc\" \\\n      --enable-obsolete-rpc
+        \\\n      --disable-profile \\\n      --enable-kernel=2.6.32 \\\n      --cache-file=config.cache\n\n    make\n  popd
+        > /dev/null\n}\n\n# Running a `make check` is considered one critical test
+        of the correctness of\n# the resulting glibc build. Unfortunetly, the time
+        to complete the test suite\n# rougly triples the build time of this Plan and
+        there are at least 2 known\n# failures which means that `make check` certainly
+        returns a non-zero exit\n# code. Despite these downsides, it is still worth
+        the pain when building the\n# first time in a new environment, or when a new
+        upstream version is attempted.\n#\n# There are known failures in `make check`,
+        but most likely known ones, given a\n# build on a full virtual machine or
+        physical server. Here are the known\n# failures and why:\n#\n# ## FAIL: elf/check-abi-libc\n#\n#
+        \"You might see a check failure due to a different size for\n# `_nl_default_dirname`
+        if you build for a different prefix using the\n# `--prefix` configure option.
+        The size of `_nl_default_dirname` depends on the\n# prefix and `/usr/share/locale`
+        is considered the default and hence the value\n# 0x12. If you see such a difference,
+        you should check that the size\n# corresponds to your prefix, i.e. `(length
+        of prefix path + 1)` to ensure that\n# you haven''t really broken abi with
+        your change.\"\n#\n# Source:\n# https://sourceware.org/glibc/wiki/Testing/Testsuite#Known_testsuite_failures\n#\n#
+        ## FAIL: posix/tst-getaddrinfo4\n#\n# \"This test will always fail due to
+        not having the necessary networking\n# applications when the tests are run.\"\n#\n#
+        Source: http://www.linuxfromscratch.org/lfs/view/stable/chapter06/glibc.html\n#\ndo_check()
+        {\n  pushd ../${pkg_name}-build > /dev/null\n    # One of the tests uses the
+        hardcoded `bin/cat` path, so we''ll add it, if\n    # it doesn''t exist.\n    #
+        Checking for the binary on `$PATH` will work in both stage1 and default\n    #
+        Studios.\n    if [[ ! -r /bin/cat ]]; then\n      ln -sv \"$(command -v cat)\"
+        /bin/cat\n      _clean_cat=true\n    fi\n    # One of the tests uses the hardcoded
+        `bin/echo` path, so we''ll add it, if\n    # it doesn''t exist.\n    if [[
+        ! -r /bin/echo ]]; then\n      # We can''t use the `command -v echo` trick
+        here, as `echo` is a shell\n      # builtin, and therefore returns the string
+        of \"echo\" (i.e. not the full\n      # path to the executable on `$PATH`).
+        In a stage1 Studio, the coreutils\n      # package isn''t built yet so we
+        can''t rely on using the `pkg_path_for`\n      # helper either. Sweet twist,
+        no?\n      if [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n        ln -sv /tools/bin/echo
+        /bin/echo\n      else\n        ln -sv \"$(pkg_path_for coreutils)/bin/echo\"
+        /bin/echo\n      fi\n      _clean_echo=true\n    fi\n\n    # \"If the test
+        system does not have suitable copies of libgcc_s.so and\n    # libstdc++.so
+        installed in system library directories, it is necessary to\n    # copy or
+        symlink them into the build directory before testing (see\n    # https://sourceware.org/ml/libc-alpha/2012-04/msg01014.html
+        regarding the\n    # use of system library directories here).\"\n    #\n    #
+        Source: https://sourceware.org/glibc/wiki/Release/2.23\n    # Source: http://www0.cs.ucl.ac.uk/staff/ucacbbl/glibc/index.html#bug-atexit3\n    if
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n      ln -sv /tools/lib/libgcc_s.so.1
+        .\n      ln -sv /tools/lib/libstdc++.so.6 .\n    else\n      ln -sv \"$(pkg_path_for
+        gcc)/lib/libgcc_s.so.1\" .\n      ln -sv \"$(pkg_path_for gcc)/lib/libstdc++.so.6\"
+        .\n    fi\n\n    # It appears as though some tests *always* fail, but since
+        the output (and\n    # passing tests) is of value, we will run the anyway.
+        Expect ignore the\n    # exit code. I am sad.\n    make check || true\n\n    rm
+        -fv ./libgcc_s.so.1 ./libstdc++.so.6\n\n    # Clean up the symlinks if we
+        set it up.\n    if [[ -n \"$_clean_echo\" ]]; then\n      rm -fv /bin/echo\n    fi\n    if
+        [[ -n \"$_clean_cat\" ]]; then\n      rm -fv /bin/cat\n    fi\n  popd > /dev/null\n}\n\ndo_install()
+        {\n  pushd ../${pkg_name}-build > /dev/null\n    # Prevent a `make install`
+        warning of a missing `ld.so.conf`.\n    mkdir -p \"$pkg_prefix/etc\"\n    touch
+        \"$pkg_prefix/etc/ld.so.conf\"\n\n    # To ensure the `make install` checks
+        at the end succeed. Unfortunately,\n    # a multilib installation is assumed
+        (i.e. 32-bit and 64-bit). We will\n    # fool this check by symlinking a \"32-bit\"
+        file to the real loader.\n    mkdir -p \"$pkg_prefix/lib\"\n    ln -sv ld-${pkg_version}.so
+        \"$pkg_prefix/lib/ld-linux.so.2\"\n\n    # Add a `lib64` -> `lib` symlink
+        for `bin/ldd` to work correctly.\n    #\n    # Thanks to: https://github.com/NixOS/nixpkgs/blob/55b03266cfc25ae019af3cdd2cfcad0facdc68f2/pkgs/development/libraries/glibc/builder.sh#L43-L47\n    ln
+        -sv lib \"$pkg_prefix/lib64\"\n\n    if [[ \"$STUDIO_TYPE\" = \"stage1\" ]];
+        then\n      # When building glibc using a build toolchain, we need libgcc_s
+        at\n      # `$RPATH` which gets us by until we can link against this for real\n      if
+        [ -f /tools/lib/libgcc_s.so.1 ]; then\n        cp -v /tools/lib/libgcc_s.so.1
+        \"$pkg_prefix/lib/\"\n        # the .so file used to be a symlink, but now
+        it is a script\n        cp -av /tools/lib/libgcc_s.so \"$pkg_prefix/lib/\"\n      fi\n    fi\n\n    make
+        install sysconfdir=\"$pkg_prefix/etc\" sbindir=\"$pkg_prefix/bin\"\n\n    #
+        Move all remaining binaries in `sbin/` into `bin/`, namely `ldconfig`\n    mv
+        \"$pkg_prefix/sbin\"/* \"$pkg_prefix/bin/\"\n    rm -rf \"$pkg_prefix/sbin\"\n\n    #
+        Remove unneeded files from `include/rpcsvc`\n    rm -fv \"$pkg_prefix/include/rpcsvc\"/*.x\n\n    #
+        Remove the `make install` check symlink\n    rm -fv \"$pkg_prefix/lib/ld-linux.so.2\"\n\n    #
+        Remove `sln` (statically built ln)--not needed\n    rm -f \"$pkg_prefix/bin/sln\"\n\n    #
+        Update the shebangs of a few shell scripts that have a fully-qualified\n    #
+        path to `/bin/sh` so they will work in a minimal busybox\n    for b in ldd
+        sotruss tzselect xtrace; do\n      sed -e ''s,^#!.*$,#! /bin/sh,'' -i \"$pkg_prefix/bin/$b\"\n    done\n\n    #
+        Include the Linux kernel headers in Glibc, except the `scsi/` directory,\n    #
+        which Glibc provides itself.\n    #\n    # We can thank GCC for this requirement;
+        we must provide a single path\n    # value for the `--with-native-system-header-dir`
+        configure option and this\n    # path must contain libc and kernel headers
+        (the assumption is we are\n    # running a common operating system with everything
+        under `/usr/include`).\n    # GCC then bakes this path in when it builds itself,
+        thus it''s pretty\n    # important for any future GCC-built packages. If there
+        is an alternate way\n    # we can make GCC happy, then we''ll change this
+        up. This is the best of a\n    # sad, sad situation.\n    #\n    # Thanks
+        to: https://github.com/NixOS/nixpkgs/blob/55b03266cfc25ae019af3cdd2cfcad0facdc68f2/pkgs/development/libraries/glibc/builder.sh#L25-L32\n    pushd
+        \"$pkg_prefix/include\" > /dev/null\n      # shellcheck disable=SC2010,SC2046\n      ln
+        -sv $(ls -d $(pkg_path_for linux-headers)/include/* | grep -v ''scsi$'') .\n    popd
+        > /dev/null\n\n    mkdir -pv \"$pkg_prefix/lib/locale\"\n    localedef -i
+        cs_CZ -f UTF-8 cs_CZ.UTF-8\n    localedef -i de_DE -f ISO-8859-1 de_DE\n    localedef
+        -i de_DE@euro -f ISO-8859-15 de_DE@euro\n    localedef -i en_HK -f ISO-8859-1
+        en_HK\n    localedef -i en_PH -f ISO-8859-1 en_PH\n    localedef -i en_US
+        -f ISO-8859-1 en_US\n    localedef -i en_US -f UTF-8 en_US\n    localedef
+        -i es_MX -f ISO-8859-1 es_MX\n    localedef -i fa_IR -f UTF-8 fa_IR\n    localedef
+        -i fr_FR -f ISO-8859-1 fr_FR\n    localedef -i fr_FR@euro -f ISO-8859-15 fr_FR@euro\n    localedef
+        -i it_IT -f ISO-8859-1 it_IT\n    localedef -i ja_JP -f EUC-JP ja_JP\n\n    cp
+        -v \"../$pkg_dirname/nscd/nscd.conf\" \"$pkg_prefix/etc/\"\n\n    cat > \"$pkg_prefix/etc/nsswitch.conf\"
+        << \"EOF\"\npasswd: files\ngroup: files\nshadow: files\n\nhosts: files dns\nnetworks:
+        files\n\nprotocols: files\nservices: files\nethers: files\nrpc: files\nEOF\n\n    extract_src
+        tzdata\n    pushd ./tzdata > /dev/null\n      ZONEINFO=\"$pkg_prefix/share/zoneinfo\"\n      mkdir
+        -p \"$ZONEINFO\"/{posix,right}\n      for tz in etcetera southamerica northamerica
+        europe africa antarctica \\\n          asia australasia backward pacificnew
+        systemv; do\n        zic -L /dev/null -d \"$ZONEINFO\" -y \"sh yearistype.sh\"
+        ${tz}\n        zic -L /dev/null -d \"$ZONEINFO/posix\" -y \"sh yearistype.sh\"
+        ${tz}\n        zic -L leapseconds -d \"$ZONEINFO/right\" -y \"sh yearistype.sh\"
+        ${tz}\n      done\n      cp -v zone.tab zone1970.tab iso3166.tab \"$ZONEINFO\"\n      zic
+        -d \"$ZONEINFO\" -p America/New_York\n      unset ZONEINFO\n    popd > /dev/null\n    cp
+        -v \"$pkg_prefix/share/zoneinfo/UTC\" \"$pkg_prefix/etc/localtime\"\n  popd
+        > /dev/null\n}\n\ndo_end() {\n  # Clean up the `pwd` link, if we set it up.\n  if
+        [[ -n \"$_clean_pwd\" ]]; then\n    rm -fv /bin/pwd\n  fi\n}\n\nextract_src()
+        {\n  build_dirname=$pkg_dirname/../${pkg_name}-build\n  plan=$1\n\n  (source
+        \"$PLAN_CONTEXT/../$plan/plan.sh\"\n    # Re-override the defaults as this
+        plan is sourced externally\n    pkg_filename=\"$(basename $pkg_source)\"\n    pkg_dirname=\"${pkg_name}-${pkg_version}\"\n    CACHE_PATH=\"$HAB_CACHE_SRC_PATH/$pkg_dirname\"\n\n    build_line
+        \"Downloading $pkg_source\"\n    do_download\n    build_line \"Verifying $pkg_filename\"\n    do_verify\n    build_line
+        \"Clean the cache\"\n    do_clean\n    build_line \"Unpacking $pkg_filename\"\n    do_unpack\n    mv
+        -v \"$HAB_CACHE_SRC_PATH/$pkg_dirname\" \\\n      \"$HAB_CACHE_SRC_PATH/$build_dirname/$plan\"\n  )\n}\n\n\n#
+        ----------------------------------------------------------------------------\n#
+        **NOTICE:** What follows are implementation details required for building
+        a\n# first-pass, \"stage1\" toolchain and environment. It is only used when
+        running\n# in a \"stage1\" Studio and can be safely ignored by almost everyone.
+        Having\n# said that, it performs a vital bootstrapping process and cannot
+        be removed or\n# significantly altered. Thank you!\n# ----------------------------------------------------------------------------\nif
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n  pkg_build_deps=()\nfi\n```","target":"x86_64-linux","tdeps":[{"name":"linux-headers","origin":"core","release":"20180608041107","version":"4.15.9"}],"visibility":"public"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 10:23:35 GMT
+- request:
+    method: get
+    uri: https://bldr.habitat.sh/v1/depot/channels/core/unstable/pkgs/musl/latest
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, range
+      Access-Control-Allow-Methods:
+      - PUT, DELETE, PATCH
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - content-disposition
+      Cache-Control:
+      - private, no-cache, no-store, private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - nginx/1.13.10
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - '0'
+      - '0'
+      - '0'
+      - '0'
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Content-Length:
+      - '1651'
+      Date:
+      - Thu, 23 Aug 2018 10:23:35 GMT
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sea1041-SEA, cache-lhr6326-LHR
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age= 7776000; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"channels":["base-plans-2018-06","stable","unstable"],"checksum":"63019db59c548ba1f12c8b238c6ef2615807dc1922b94293606fc8e7f2ed9d30","config":"","deps":[],"exposes":[],"ident":{"name":"musl","origin":"core","release":"20180608102708","version":"1.1.19"},"is_a_service":false,"manifest":"#
+        core / musl\nmusl is a new standard library to power a new generation of Linux-based
+        devices. musl is lightweight, fast, simple, free, and strives to be correct
+        in the sense of standards-conformance and safety.\n\n* __Maintainer__: The
+        Habitat Maintainers <humans@habitat.sh>\n* __Version__: 1.1.19\n* __Release__:
+        20180608102708\n* __Architecture__: x86_64\n* __System__: linux\n* __Target__:
+        x86_64-linux\n* __Upstream URL__: [https://www.musl-libc.org/](https://www.musl-libc.org/)\n*
+        __License__: MIT \n* __Source__: [http://www.musl-libc.org/releases/musl-1.1.19.tar.gz](http://www.musl-libc.org/releases/musl-1.1.19.tar.gz)\n*
+        __SHA__: `db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9`\n*
+        __Path__: `/hab/pkgs/core/musl/1.1.19/20180608102708`\n* __Build Dependencies__:
+        `core/coreutils core/diffutils core/gcc core/make core/patch core/sed `\n*
+        __Dependencies__: no runtime dependencies or undefined\n* __Interpreters__:
+        no interpreters or undefined\n\n# Plan\n\n## Build Flags\n\n```bash\nCFLAGS:
+        -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include\nCPPFLAGS:
+        -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include\nCXXFLAGS:
+        -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include\nLDFLAGS:
+        -L/hab/pkgs/core/gcc/7.3.0/20180608051919/lib\nLD_RUN_PATH: /hab/pkgs/core/musl/1.1.19/20180608102708/lib\n```\n\n##
+        Plan Source\n\n```bash\npkg_name=musl\npkg_origin=core\npkg_version=1.1.19\npkg_maintainer=\"The
+        Habitat Maintainers <humans@habitat.sh>\"\npkg_description=\"\\\nmusl is a
+        new standard library to power a new generation of Linux-based \\\ndevices.
+        musl is lightweight, fast, simple, free, and strives to be correct \\\nin
+        the sense of standards-conformance and safety.\\\n\"\npkg_upstream_url=\"https://www.musl-libc.org/\"\npkg_license=(''MIT'')\npkg_source=\"http://www.musl-libc.org/releases/${pkg_name}-${pkg_version}.tar.gz\"\npkg_shasum=\"db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9\"\npkg_deps=()\npkg_build_deps=(\n  core/coreutils\n  core/diffutils\n  core/gcc\n  core/make\n  core/patch\n  core/sed\n)\npkg_bin_dirs=(bin)\npkg_include_dirs=(include)\npkg_lib_dirs=(lib)\n\ndo_prepare()
+        {\n  stack_size=\"2097152\"\n  build_line \"Setting default stack size to
+        ''$stack_size'' from default ''81920''\"\n  sed \\\n    -i \"s/#define DEFAULT_STACK_SIZE
+        .*/#define DEFAULT_STACK_SIZE $stack_size/\" \\\n    src/internal/pthread_impl.h\n}\n\ndo_build()
+        {\n  ./configure \\\n    --prefix=\"$pkg_prefix\" \\\n    --syslibdir=\"$pkg_prefix/lib\"\n  make
+        -j \"$(nproc)\"\n}\n\ndo_install() {\n  do_default_install\n\n  # Install
+        license\n  install -Dm0644 COPYRIGHT \"$pkg_prefix/share/licenses/COPYRIGHT\"\n}\n\n\n#
+        ----------------------------------------------------------------------------\n#
+        **NOTICE:** What follows are implementation details required for building
+        a\n# first-pass, \"stage1\" toolchain and environment. It is only used when
+        running\n# in a \"stage1\" Studio and can be safely ignored by almost everyone.
+        Having\n# said that, it performs a vital bootstrapping process and cannot
+        be removed or\n# significantly altered. Thank you!\n# ----------------------------------------------------------------------------\nif
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n  pkg_build_deps=(\n    core/gcc\n    core/coreutils\n    core/sed\n    core/diffutils\n    core/make\n    core/patch\n  )\nfi\n```","target":"x86_64-linux","tdeps":[],"visibility":"public"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 10:23:36 GMT
+- request:
+    method: get
+    uri: https://bldr.habitat.sh/v1/depot/channels/core/unstable/pkgs/glibc/2.27/20180608041157
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, range
+      Access-Control-Allow-Methods:
+      - PUT, DELETE, PATCH
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - content-disposition
+      Alternate-Protocol:
+      - 443:npn-spdy/3
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - nginx/1.13.10
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - '0'
+      - '0'
+      - '0'
+      - '0'
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Content-Length:
+      - '6591'
+      Date:
+      - Thu, 23 Aug 2018 10:23:36 GMT
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sea1036-SEA, cache-lhr6329-LHR
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age= 7776000; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"channels":["base-plans-2018-06","stable","unstable"],"checksum":"953093152ce8208332cebcb87e625069a68486ce502874792e9867e6ef7ae6f0","config":"","deps":[{"name":"linux-headers","origin":"core","release":"20180608041107","version":"4.15.9"}],"exposes":[],"ident":{"name":"glibc","origin":"core","release":"20180608041157","version":"2.27"},"is_a_service":false,"manifest":"#
+        core / glibc\nThe GNU C Library project provides the core libraries for the
+        GNU system and GNU/Linux systems, as well as many other systems that use Linux
+        as the kernel. These libraries provide critical APIs including ISO C11, POSIX.1-2008,
+        BSD, OS-specific APIs and more. These APIs include such foundational facilities
+        as open, read, write, malloc, printf, getaddrinfo, dlopen, pthread_create,
+        crypt, login, exit and more.\n\n* __Maintainer__: The Habitat Maintainers
+        <humans@habitat.sh>\n* __Version__: 2.27\n* __Release__: 20180608041157\n*
+        __Architecture__: x86_64\n* __System__: linux\n* __Target__: x86_64-linux\n*
+        __Upstream URL__: [https://www.gnu.org/software/libc](https://www.gnu.org/software/libc)\n*
+        __License__: GPL-2.0 LGPL-2.0 \n* __Source__: [http://ftp.gnu.org/gnu/glibc/glibc-2.27.tar.xz](http://ftp.gnu.org/gnu/glibc/glibc-2.27.tar.xz)\n*
+        __SHA__: `5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72`\n*
+        __Path__: `/hab/pkgs/core/glibc/2.27/20180608041157`\n* __Build Dependencies__:
+        `core/coreutils core/bison core/diffutils core/patch core/make core/gcc core/sed
+        core/perl `\n* __Dependencies__: `core/linux-headers `\n* __Interpreters__:
+        no interpreters or undefined\n\n# Plan\n\n## Build Flags\n\n```bash\nCFLAGS:
+        no CFLAGS\nCPPFLAGS: -I/hab/pkgs/core/linux-headers/4.15.9/20180608041107/include
+        -I/hab/pkgs/core/make/4.2.1/20180608031320/include -I/hab/pkgs/core/gcc/7.3.0/20180607201502/include\nCXXFLAGS:
+        -I/hab/pkgs/core/linux-headers/4.15.9/20180608041107/include -I/hab/pkgs/core/make/4.2.1/20180608031320/include
+        -I/hab/pkgs/core/gcc/7.3.0/20180607201502/include\nLDFLAGS: -Wl,--dynamic-linker=/hab/pkgs/core/glibc/2.27/20180608041157/lib/ld-linux-x86-64.so.2\nLD_RUN_PATH:
+        no LD_RUN_PATH\n```\n\n## Plan Source\n\n```bash\npkg_name=glibc\npkg_origin=core\npkg_version=2.27\npkg_maintainer=\"The
+        Habitat Maintainers <humans@habitat.sh>\"\npkg_description=\"\\\nThe GNU C
+        Library project provides the core libraries for the GNU system and \\\nGNU/Linux
+        systems, as well as many other systems that use Linux as the \\\nkernel. These
+        libraries provide critical APIs including ISO C11, \\\nPOSIX.1-2008, BSD,
+        OS-specific APIs and more. These APIs include such \\\nfoundational facilities
+        as open, read, write, malloc, printf, getaddrinfo, \\\ndlopen, pthread_create,
+        crypt, login, exit and more.\\\n\"\npkg_upstream_url=\"https://www.gnu.org/software/libc\"\npkg_license=(''GPL-2.0''
+        ''LGPL-2.0'')\npkg_source=\"http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.xz\"\npkg_shasum=\"5172de54318ec0b7f2735e5a91d908afe1c9ca291fec16b5374d9faadfc1fc72\"\npkg_deps=(\n  core/linux-headers\n)\npkg_build_deps=(\n  core/coreutils\n  core/bison\n  core/diffutils\n  core/patch\n  core/make\n  core/gcc\n  core/sed\n  core/perl\n)\npkg_bin_dirs=(bin)\npkg_include_dirs=(include)\npkg_lib_dirs=(lib)\n\ndo_prepare()
+        {\n  # The `/bin/pwd` path is hardcoded, so we''ll add a symlink if needed.\n  if
+        [[ ! -r /bin/pwd ]]; then\n    # We can''t use the `command -v pwd` trick
+        here, as `pwd` is a shell\n    # builtin, and therefore returns the string
+        of \"pwd\" (i.e. not the full\n    # path to the executable on `$PATH`). In
+        a stage1 Studio, the coreutils\n    # package isn''t built yet so we can''t
+        rely on using the `pkg_path_for`\n    # helper either.  Sweet twist, no?\n    if
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n      ln -sv /tools/bin/pwd /bin/pwd\n    else\n      ln
+        -sv \"$(pkg_path_for coreutils)/bin/pwd\" /bin/pwd\n    fi\n    _clean_pwd=true\n  fi\n\n  #
+        Determine the full path to the linker which will be produced.\n  dynamic_linker=\"$pkg_prefix/lib/ld-linux-x86-64.so.2\"\n\n  #
+        We don''t want glibc to try and reference itself before it''s installed,\n  #
+        no `$LD_RUN_PATH`s here\n  unset LD_RUN_PATH\n  build_line \"Overriding LD_RUN_PATH=$LD_RUN_PATH\"\n\n  unset
+        CFLAGS\n  build_line \"Overriding CFLAGS=$CFLAGS\"\n\n  # Add a dynamic-linker
+        option to `$LDFLAGS` so that every dynamic ELF binary\n  # will use our own
+        dynamic linker and not a previously built version.\n  LDFLAGS=\"-Wl,--dynamic-linker=$dynamic_linker\"\n  build_line
+        \"Setting LDFLAGS=$LDFLAGS\"\n\n  # Don''t depend on dynamically linked libgcc
+        for nscd, as we don''t want it\n  # depending on any bootstrapped version.\n  echo
+        \"LDFLAGS-nscd += -static-libgcc\" >> nscd/Makefile\n\n  # Have `rpcgen(1)`
+        look for `cpp(1)` in `$PATH`.\n  # Thanks to https://github.com/NixOS/nixpkgs/blob/1b55b07/pkgs/development/libraries/glibc/rpcgen-path.patch\n  patch
+        -p1 < \"$PLAN_CONTEXT/rpcgen-path.patch\"\n\n  # Don''t use the system''s
+        `/etc/ld.so.cache` and `/etc/ld.so.preload`, but\n  # rather the version under
+        `$pkg_prefix/etc`.\n  #\n  # Thanks to https://github.com/NixOS/nixpkgs/blob/54fc2db/pkgs/development/libraries/glibc/dont-use-system-ld-so-cache.patch\n  #
+        and to https://github.com/NixOS/nixpkgs/blob/dac591a/pkgs/development/libraries/glibc/dont-use-system-ld-so-preload.patch\n  #
+        shellcheck disable=SC2002\n  cat \"$PLAN_CONTEXT/dont-use-system-ld-so.patch\"
+        \\\n    | sed \"s,@prefix@,$pkg_prefix,g\" \\\n    | patch -p1\n\n  # Fix
+        for the scanf15 and scanf17 tests for arches that need\n  # misc/bits/syscall.h.
+        This problem is present once a custom location is used\n  # for the Linux
+        Kernel headers.\n  #\n  # Source: https://lists.debian.org/debian-glibc/2013/11/msg00116.html\n  patch
+        -p1 < \"$PLAN_CONTEXT/testsuite-fix.patch\"\n\n  # Adjust `scripts/test-installation.pl`
+        to use our new dynamic linker\n  sed -i \"s|libs -o|libs -L${pkg_prefix}/lib
+        -Wl,-dynamic-linker=${dynamic_linker} -o|\" \\\n    scripts/test-installation.pl\n}\n\ndo_build()
+        {\n  rm -rf ../${pkg_name}-build\n  mkdir ../${pkg_name}-build\n  pushd ../${pkg_name}-build
+        > /dev/null\n    # Configure Glibc to install its libraries into `$pkg_prefix/lib`\n    echo
+        \"libc_cv_slibdir=$pkg_prefix/lib\" >> config.cache\n    echo \"libc_cv_ssp=no\"
+        >> config.cache\n\n    \"../$pkg_dirname/configure\" \\\n      --prefix=\"$pkg_prefix\"
+        \\\n      --sbindir=\"$pkg_prefix/bin\" \\\n      --with-headers=\"$(pkg_path_for
+        linux-headers)/include\" \\\n      --libdir=\"$pkg_prefix/lib\" \\\n      --libexecdir=\"$pkg_prefix/lib/glibc\"
+        \\\n      --sysconfdir=\"$pkg_prefix/etc\" \\\n      --enable-obsolete-rpc
+        \\\n      --disable-profile \\\n      --enable-kernel=2.6.32 \\\n      --cache-file=config.cache\n\n    make\n  popd
+        > /dev/null\n}\n\n# Running a `make check` is considered one critical test
+        of the correctness of\n# the resulting glibc build. Unfortunetly, the time
+        to complete the test suite\n# rougly triples the build time of this Plan and
+        there are at least 2 known\n# failures which means that `make check` certainly
+        returns a non-zero exit\n# code. Despite these downsides, it is still worth
+        the pain when building the\n# first time in a new environment, or when a new
+        upstream version is attempted.\n#\n# There are known failures in `make check`,
+        but most likely known ones, given a\n# build on a full virtual machine or
+        physical server. Here are the known\n# failures and why:\n#\n# ## FAIL: elf/check-abi-libc\n#\n#
+        \"You might see a check failure due to a different size for\n# `_nl_default_dirname`
+        if you build for a different prefix using the\n# `--prefix` configure option.
+        The size of `_nl_default_dirname` depends on the\n# prefix and `/usr/share/locale`
+        is considered the default and hence the value\n# 0x12. If you see such a difference,
+        you should check that the size\n# corresponds to your prefix, i.e. `(length
+        of prefix path + 1)` to ensure that\n# you haven''t really broken abi with
+        your change.\"\n#\n# Source:\n# https://sourceware.org/glibc/wiki/Testing/Testsuite#Known_testsuite_failures\n#\n#
+        ## FAIL: posix/tst-getaddrinfo4\n#\n# \"This test will always fail due to
+        not having the necessary networking\n# applications when the tests are run.\"\n#\n#
+        Source: http://www.linuxfromscratch.org/lfs/view/stable/chapter06/glibc.html\n#\ndo_check()
+        {\n  pushd ../${pkg_name}-build > /dev/null\n    # One of the tests uses the
+        hardcoded `bin/cat` path, so we''ll add it, if\n    # it doesn''t exist.\n    #
+        Checking for the binary on `$PATH` will work in both stage1 and default\n    #
+        Studios.\n    if [[ ! -r /bin/cat ]]; then\n      ln -sv \"$(command -v cat)\"
+        /bin/cat\n      _clean_cat=true\n    fi\n    # One of the tests uses the hardcoded
+        `bin/echo` path, so we''ll add it, if\n    # it doesn''t exist.\n    if [[
+        ! -r /bin/echo ]]; then\n      # We can''t use the `command -v echo` trick
+        here, as `echo` is a shell\n      # builtin, and therefore returns the string
+        of \"echo\" (i.e. not the full\n      # path to the executable on `$PATH`).
+        In a stage1 Studio, the coreutils\n      # package isn''t built yet so we
+        can''t rely on using the `pkg_path_for`\n      # helper either. Sweet twist,
+        no?\n      if [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n        ln -sv /tools/bin/echo
+        /bin/echo\n      else\n        ln -sv \"$(pkg_path_for coreutils)/bin/echo\"
+        /bin/echo\n      fi\n      _clean_echo=true\n    fi\n\n    # \"If the test
+        system does not have suitable copies of libgcc_s.so and\n    # libstdc++.so
+        installed in system library directories, it is necessary to\n    # copy or
+        symlink them into the build directory before testing (see\n    # https://sourceware.org/ml/libc-alpha/2012-04/msg01014.html
+        regarding the\n    # use of system library directories here).\"\n    #\n    #
+        Source: https://sourceware.org/glibc/wiki/Release/2.23\n    # Source: http://www0.cs.ucl.ac.uk/staff/ucacbbl/glibc/index.html#bug-atexit3\n    if
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n      ln -sv /tools/lib/libgcc_s.so.1
+        .\n      ln -sv /tools/lib/libstdc++.so.6 .\n    else\n      ln -sv \"$(pkg_path_for
+        gcc)/lib/libgcc_s.so.1\" .\n      ln -sv \"$(pkg_path_for gcc)/lib/libstdc++.so.6\"
+        .\n    fi\n\n    # It appears as though some tests *always* fail, but since
+        the output (and\n    # passing tests) is of value, we will run the anyway.
+        Expect ignore the\n    # exit code. I am sad.\n    make check || true\n\n    rm
+        -fv ./libgcc_s.so.1 ./libstdc++.so.6\n\n    # Clean up the symlinks if we
+        set it up.\n    if [[ -n \"$_clean_echo\" ]]; then\n      rm -fv /bin/echo\n    fi\n    if
+        [[ -n \"$_clean_cat\" ]]; then\n      rm -fv /bin/cat\n    fi\n  popd > /dev/null\n}\n\ndo_install()
+        {\n  pushd ../${pkg_name}-build > /dev/null\n    # Prevent a `make install`
+        warning of a missing `ld.so.conf`.\n    mkdir -p \"$pkg_prefix/etc\"\n    touch
+        \"$pkg_prefix/etc/ld.so.conf\"\n\n    # To ensure the `make install` checks
+        at the end succeed. Unfortunately,\n    # a multilib installation is assumed
+        (i.e. 32-bit and 64-bit). We will\n    # fool this check by symlinking a \"32-bit\"
+        file to the real loader.\n    mkdir -p \"$pkg_prefix/lib\"\n    ln -sv ld-${pkg_version}.so
+        \"$pkg_prefix/lib/ld-linux.so.2\"\n\n    # Add a `lib64` -> `lib` symlink
+        for `bin/ldd` to work correctly.\n    #\n    # Thanks to: https://github.com/NixOS/nixpkgs/blob/55b03266cfc25ae019af3cdd2cfcad0facdc68f2/pkgs/development/libraries/glibc/builder.sh#L43-L47\n    ln
+        -sv lib \"$pkg_prefix/lib64\"\n\n    if [[ \"$STUDIO_TYPE\" = \"stage1\" ]];
+        then\n      # When building glibc using a build toolchain, we need libgcc_s
+        at\n      # `$RPATH` which gets us by until we can link against this for real\n      if
+        [ -f /tools/lib/libgcc_s.so.1 ]; then\n        cp -v /tools/lib/libgcc_s.so.1
+        \"$pkg_prefix/lib/\"\n        # the .so file used to be a symlink, but now
+        it is a script\n        cp -av /tools/lib/libgcc_s.so \"$pkg_prefix/lib/\"\n      fi\n    fi\n\n    make
+        install sysconfdir=\"$pkg_prefix/etc\" sbindir=\"$pkg_prefix/bin\"\n\n    #
+        Move all remaining binaries in `sbin/` into `bin/`, namely `ldconfig`\n    mv
+        \"$pkg_prefix/sbin\"/* \"$pkg_prefix/bin/\"\n    rm -rf \"$pkg_prefix/sbin\"\n\n    #
+        Remove unneeded files from `include/rpcsvc`\n    rm -fv \"$pkg_prefix/include/rpcsvc\"/*.x\n\n    #
+        Remove the `make install` check symlink\n    rm -fv \"$pkg_prefix/lib/ld-linux.so.2\"\n\n    #
+        Remove `sln` (statically built ln)--not needed\n    rm -f \"$pkg_prefix/bin/sln\"\n\n    #
+        Update the shebangs of a few shell scripts that have a fully-qualified\n    #
+        path to `/bin/sh` so they will work in a minimal busybox\n    for b in ldd
+        sotruss tzselect xtrace; do\n      sed -e ''s,^#!.*$,#! /bin/sh,'' -i \"$pkg_prefix/bin/$b\"\n    done\n\n    #
+        Include the Linux kernel headers in Glibc, except the `scsi/` directory,\n    #
+        which Glibc provides itself.\n    #\n    # We can thank GCC for this requirement;
+        we must provide a single path\n    # value for the `--with-native-system-header-dir`
+        configure option and this\n    # path must contain libc and kernel headers
+        (the assumption is we are\n    # running a common operating system with everything
+        under `/usr/include`).\n    # GCC then bakes this path in when it builds itself,
+        thus it''s pretty\n    # important for any future GCC-built packages. If there
+        is an alternate way\n    # we can make GCC happy, then we''ll change this
+        up. This is the best of a\n    # sad, sad situation.\n    #\n    # Thanks
+        to: https://github.com/NixOS/nixpkgs/blob/55b03266cfc25ae019af3cdd2cfcad0facdc68f2/pkgs/development/libraries/glibc/builder.sh#L25-L32\n    pushd
+        \"$pkg_prefix/include\" > /dev/null\n      # shellcheck disable=SC2010,SC2046\n      ln
+        -sv $(ls -d $(pkg_path_for linux-headers)/include/* | grep -v ''scsi$'') .\n    popd
+        > /dev/null\n\n    mkdir -pv \"$pkg_prefix/lib/locale\"\n    localedef -i
+        cs_CZ -f UTF-8 cs_CZ.UTF-8\n    localedef -i de_DE -f ISO-8859-1 de_DE\n    localedef
+        -i de_DE@euro -f ISO-8859-15 de_DE@euro\n    localedef -i en_HK -f ISO-8859-1
+        en_HK\n    localedef -i en_PH -f ISO-8859-1 en_PH\n    localedef -i en_US
+        -f ISO-8859-1 en_US\n    localedef -i en_US -f UTF-8 en_US\n    localedef
+        -i es_MX -f ISO-8859-1 es_MX\n    localedef -i fa_IR -f UTF-8 fa_IR\n    localedef
+        -i fr_FR -f ISO-8859-1 fr_FR\n    localedef -i fr_FR@euro -f ISO-8859-15 fr_FR@euro\n    localedef
+        -i it_IT -f ISO-8859-1 it_IT\n    localedef -i ja_JP -f EUC-JP ja_JP\n\n    cp
+        -v \"../$pkg_dirname/nscd/nscd.conf\" \"$pkg_prefix/etc/\"\n\n    cat > \"$pkg_prefix/etc/nsswitch.conf\"
+        << \"EOF\"\npasswd: files\ngroup: files\nshadow: files\n\nhosts: files dns\nnetworks:
+        files\n\nprotocols: files\nservices: files\nethers: files\nrpc: files\nEOF\n\n    extract_src
+        tzdata\n    pushd ./tzdata > /dev/null\n      ZONEINFO=\"$pkg_prefix/share/zoneinfo\"\n      mkdir
+        -p \"$ZONEINFO\"/{posix,right}\n      for tz in etcetera southamerica northamerica
+        europe africa antarctica \\\n          asia australasia backward pacificnew
+        systemv; do\n        zic -L /dev/null -d \"$ZONEINFO\" -y \"sh yearistype.sh\"
+        ${tz}\n        zic -L /dev/null -d \"$ZONEINFO/posix\" -y \"sh yearistype.sh\"
+        ${tz}\n        zic -L leapseconds -d \"$ZONEINFO/right\" -y \"sh yearistype.sh\"
+        ${tz}\n      done\n      cp -v zone.tab zone1970.tab iso3166.tab \"$ZONEINFO\"\n      zic
+        -d \"$ZONEINFO\" -p America/New_York\n      unset ZONEINFO\n    popd > /dev/null\n    cp
+        -v \"$pkg_prefix/share/zoneinfo/UTC\" \"$pkg_prefix/etc/localtime\"\n  popd
+        > /dev/null\n}\n\ndo_end() {\n  # Clean up the `pwd` link, if we set it up.\n  if
+        [[ -n \"$_clean_pwd\" ]]; then\n    rm -fv /bin/pwd\n  fi\n}\n\nextract_src()
+        {\n  build_dirname=$pkg_dirname/../${pkg_name}-build\n  plan=$1\n\n  (source
+        \"$PLAN_CONTEXT/../$plan/plan.sh\"\n    # Re-override the defaults as this
+        plan is sourced externally\n    pkg_filename=\"$(basename $pkg_source)\"\n    pkg_dirname=\"${pkg_name}-${pkg_version}\"\n    CACHE_PATH=\"$HAB_CACHE_SRC_PATH/$pkg_dirname\"\n\n    build_line
+        \"Downloading $pkg_source\"\n    do_download\n    build_line \"Verifying $pkg_filename\"\n    do_verify\n    build_line
+        \"Clean the cache\"\n    do_clean\n    build_line \"Unpacking $pkg_filename\"\n    do_unpack\n    mv
+        -v \"$HAB_CACHE_SRC_PATH/$pkg_dirname\" \\\n      \"$HAB_CACHE_SRC_PATH/$build_dirname/$plan\"\n  )\n}\n\n\n#
+        ----------------------------------------------------------------------------\n#
+        **NOTICE:** What follows are implementation details required for building
+        a\n# first-pass, \"stage1\" toolchain and environment. It is only used when
+        running\n# in a \"stage1\" Studio and can be safely ignored by almost everyone.
+        Having\n# said that, it performs a vital bootstrapping process and cannot
+        be removed or\n# significantly altered. Thank you!\n# ----------------------------------------------------------------------------\nif
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n  pkg_build_deps=()\nfi\n```","target":"x86_64-linux","tdeps":[{"name":"linux-headers","origin":"core","release":"20180608041107","version":"4.15.9"}],"visibility":"public"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 10:23:36 GMT
+- request:
+    method: get
+    uri: https://bldr.habitat.sh/v1/depot/channels/core/unstable/pkgs/musl/1.1.19/20180608102708
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, range
+      Access-Control-Allow-Methods:
+      - PUT, DELETE, PATCH
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - content-disposition
+      Alternate-Protocol:
+      - 443:npn-spdy/3
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - nginx/1.13.10
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - '0'
+      - '0'
+      - '0'
+      - '0'
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Content-Length:
+      - '1651'
+      Date:
+      - Thu, 23 Aug 2018 10:23:36 GMT
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sea1046-SEA, cache-lhr6321-LHR
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age= 7776000; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"channels":["base-plans-2018-06","stable","unstable"],"checksum":"63019db59c548ba1f12c8b238c6ef2615807dc1922b94293606fc8e7f2ed9d30","config":"","deps":[],"exposes":[],"ident":{"name":"musl","origin":"core","release":"20180608102708","version":"1.1.19"},"is_a_service":false,"manifest":"#
+        core / musl\nmusl is a new standard library to power a new generation of Linux-based
+        devices. musl is lightweight, fast, simple, free, and strives to be correct
+        in the sense of standards-conformance and safety.\n\n* __Maintainer__: The
+        Habitat Maintainers <humans@habitat.sh>\n* __Version__: 1.1.19\n* __Release__:
+        20180608102708\n* __Architecture__: x86_64\n* __System__: linux\n* __Target__:
+        x86_64-linux\n* __Upstream URL__: [https://www.musl-libc.org/](https://www.musl-libc.org/)\n*
+        __License__: MIT \n* __Source__: [http://www.musl-libc.org/releases/musl-1.1.19.tar.gz](http://www.musl-libc.org/releases/musl-1.1.19.tar.gz)\n*
+        __SHA__: `db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9`\n*
+        __Path__: `/hab/pkgs/core/musl/1.1.19/20180608102708`\n* __Build Dependencies__:
+        `core/coreutils core/diffutils core/gcc core/make core/patch core/sed `\n*
+        __Dependencies__: no runtime dependencies or undefined\n* __Interpreters__:
+        no interpreters or undefined\n\n# Plan\n\n## Build Flags\n\n```bash\nCFLAGS:
+        -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include\nCPPFLAGS:
+        -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include\nCXXFLAGS:
+        -I/hab/pkgs/core/gcc/7.3.0/20180608051919/include -I/hab/pkgs/core/make/4.2.1/20180608100733/include\nLDFLAGS:
+        -L/hab/pkgs/core/gcc/7.3.0/20180608051919/lib\nLD_RUN_PATH: /hab/pkgs/core/musl/1.1.19/20180608102708/lib\n```\n\n##
+        Plan Source\n\n```bash\npkg_name=musl\npkg_origin=core\npkg_version=1.1.19\npkg_maintainer=\"The
+        Habitat Maintainers <humans@habitat.sh>\"\npkg_description=\"\\\nmusl is a
+        new standard library to power a new generation of Linux-based \\\ndevices.
+        musl is lightweight, fast, simple, free, and strives to be correct \\\nin
+        the sense of standards-conformance and safety.\\\n\"\npkg_upstream_url=\"https://www.musl-libc.org/\"\npkg_license=(''MIT'')\npkg_source=\"http://www.musl-libc.org/releases/${pkg_name}-${pkg_version}.tar.gz\"\npkg_shasum=\"db59a8578226b98373f5b27e61f0dd29ad2456f4aa9cec587ba8c24508e4c1d9\"\npkg_deps=()\npkg_build_deps=(\n  core/coreutils\n  core/diffutils\n  core/gcc\n  core/make\n  core/patch\n  core/sed\n)\npkg_bin_dirs=(bin)\npkg_include_dirs=(include)\npkg_lib_dirs=(lib)\n\ndo_prepare()
+        {\n  stack_size=\"2097152\"\n  build_line \"Setting default stack size to
+        ''$stack_size'' from default ''81920''\"\n  sed \\\n    -i \"s/#define DEFAULT_STACK_SIZE
+        .*/#define DEFAULT_STACK_SIZE $stack_size/\" \\\n    src/internal/pthread_impl.h\n}\n\ndo_build()
+        {\n  ./configure \\\n    --prefix=\"$pkg_prefix\" \\\n    --syslibdir=\"$pkg_prefix/lib\"\n  make
+        -j \"$(nproc)\"\n}\n\ndo_install() {\n  do_default_install\n\n  # Install
+        license\n  install -Dm0644 COPYRIGHT \"$pkg_prefix/share/licenses/COPYRIGHT\"\n}\n\n\n#
+        ----------------------------------------------------------------------------\n#
+        **NOTICE:** What follows are implementation details required for building
+        a\n# first-pass, \"stage1\" toolchain and environment. It is only used when
+        running\n# in a \"stage1\" Studio and can be safely ignored by almost everyone.
+        Having\n# said that, it performs a vital bootstrapping process and cannot
+        be removed or\n# significantly altered. Thank you!\n# ----------------------------------------------------------------------------\nif
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n  pkg_build_deps=(\n    core/gcc\n    core/coreutils\n    core/sed\n    core/diffutils\n    core/make\n    core/patch\n  )\nfi\n```","target":"x86_64-linux","tdeps":[],"visibility":"public"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 10:23:36 GMT
+- request:
+    method: get
+    uri: https://bldr.habitat.sh/v1/depot/channels/core/unstable/pkgs/linux-headers/4.15.9/20180608041107
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Headers:
+      - authorization, range
+      Access-Control-Allow-Methods:
+      - PUT, DELETE, PATCH
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - content-disposition
+      Alternate-Protocol:
+      - 443:npn-spdy/3
+      Cache-Control:
+      - private, no-cache, no-store
+      Content-Type:
+      - application/json; charset=utf-8
+      Server:
+      - nginx/1.13.10
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      X-Xss-Protection:
+      - 1; mode=block
+      Accept-Ranges:
+      - bytes
+      - bytes
+      - bytes
+      - bytes
+      Age:
+      - '0'
+      - '0'
+      - '0'
+      - '0'
+      Via:
+      - 1.1 varnish
+      - 1.1 varnish
+      Content-Length:
+      - '1366'
+      Date:
+      - Thu, 23 Aug 2018 10:23:36 GMT
+      Connection:
+      - keep-alive
+      X-Served-By:
+      - cache-sea1022-SEA, cache-lhr6334-LHR
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      Vary:
+      - Accept-Encoding
+      Strict-Transport-Security:
+      - max-age= 7776000; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"channels":["base-plans-2018-06","stable","unstable"],"checksum":"a8d8f5f74c5bde1f5078bc344bc52ef97a28a0325203673268aa9986b532fa85","config":"","deps":[],"exposes":[],"ident":{"name":"linux-headers","origin":"core","release":"20180608041107","version":"4.15.9"},"is_a_service":false,"manifest":"#
+        core / linux-headers\nThe Linux kernel headers\n\n* __Maintainer__: The Habitat
+        Maintainers <humans@habitat.sh>\n* __Version__: 4.15.9\n* __Release__: 20180608041107\n*
+        __Architecture__: x86_64\n* __System__: linux\n* __Target__: x86_64-linux\n*
+        __Upstream URL__: [https://kernel.org](https://kernel.org)\n* __License__:
+        gplv2 \n* __Source__: [https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.15.9.tar.xz](https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.15.9.tar.xz)\n*
+        __SHA__: `dda015b2042e71c6d0df56de553846df1252eac486514000c76b741cde6d4492`\n*
+        __Path__: `/hab/pkgs/core/linux-headers/4.15.9/20180608041107`\n* __Build
+        Dependencies__: `core/coreutils core/diffutils core/patch core/make core/gcc
+        `\n* __Dependencies__: no runtime dependencies or undefined\n* __Interpreters__:
+        no interpreters or undefined\n\n# Plan\n\n## Build Flags\n\n```bash\nCFLAGS:
+        -I/hab/pkgs/core/make/4.2.1/20180608031320/include -I/hab/pkgs/core/gcc/7.3.0/20180607201502/include\nCPPFLAGS:
+        -I/hab/pkgs/core/make/4.2.1/20180608031320/include -I/hab/pkgs/core/gcc/7.3.0/20180607201502/include\nCXXFLAGS:
+        -I/hab/pkgs/core/make/4.2.1/20180608031320/include -I/hab/pkgs/core/gcc/7.3.0/20180607201502/include\nLDFLAGS:
+        -L/hab/pkgs/core/gcc/7.3.0/20180607201502/lib\nLD_RUN_PATH: no LD_RUN_PATH\n```\n\n##
+        Plan Source\n\n```bash\npkg_name=linux-headers\npkg_origin=core\npkg_version=4.15.9\npkg_maintainer=\"The
+        Habitat Maintainers <humans@habitat.sh>\"\npkg_description=\"The Linux kernel
+        headers\"\npkg_upstream_url=\"https://kernel.org\"\npkg_license=(''gplv2'')\npkg_source=\"https://www.kernel.org/pub/linux/kernel/v4.x/linux-${pkg_version}.tar.xz\"\npkg_shasum=\"dda015b2042e71c6d0df56de553846df1252eac486514000c76b741cde6d4492\"\npkg_dirname=\"linux-$pkg_version\"\npkg_deps=()\npkg_build_deps=(\n  core/coreutils\n  core/diffutils\n  core/patch\n  core/make\n  core/gcc\n)\npkg_include_dirs=(include)\n\ndo_build()
+        {\n  make headers_install ARCH=x86 INSTALL_HDR_PATH=\"$pkg_prefix\"\n}\n\ndo_install()
+        {\n  find \"$pkg_prefix/include\" \\\n    \\( -name ..install.cmd -o -name
+        .install \\) \\\n    -print0 \\\n  | xargs -0 rm -v\n}\n\n\n# ----------------------------------------------------------------------------\n#
+        **NOTICE:** What follows are implementation details required for building
+        a\n# first-pass, \"stage1\" toolchain and environment. It is only used when
+        running\n# in a \"stage1\" Studio and can be safely ignored by almost everyone.
+        Having\n# said that, it performs a vital bootstrapping process and cannot
+        be removed or\n# significantly altered. Thank you!\n# ----------------------------------------------------------------------------\nif
+        [[ \"$STUDIO_TYPE\" = \"stage1\" ]]; then\n  pkg_build_deps=()\nfi\n```","target":"x86_64-linux","tdeps":[],"visibility":"public"}'
+    http_version: 
+  recorded_at: Thu, 23 Aug 2018 10:23:36 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
Some projects may use channels other than /stable/ to publish their
packages. License scout was previously assuming all dependencies
should live in stable. Now, users can configure the channel that
should be used for a given origin via a new configuration option.

This feature feels in line with the Habitat feature HAB_BLDR_CHANNEL
which allows a user to configure their entire build to point at a
custom channel.

Signed-off-by: Steven Danna <steve@chef.io>