### PR TITLE
Add interception as a MIT project

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -370,6 +370,7 @@ module LicenseScout
         ["http_parser.rb", nil, ["https://raw.githubusercontent.com/tmm1/http_parser.rb/master/LICENSE-MIT"]],
         ["inspec-msccm", nil, [canonical("Chef-MLSA")]],
         ["inspec-scap", nil, [canonical("Chef-MLSA")]],
+        ["interception", "MIT", ["https://raw.githubusercontent.com/ConradIrwin/interception/master/LICENSE.MIT"]],
         ["jaro_winkler", "MIT", ["https://raw.githubusercontent.com/tonytonyjan/jaro_winkler/master/LICENSE.txt"]],
         ["json_pure", nil, ["https://raw.githubusercontent.com/flori/json/master/README.md"]],
         ["jwt", nil, ["https://raw.githubusercontent.com/jwt/ruby-jwt/master/LICENSE"]],


### PR DESCRIPTION
## Description

chef-server omnibus builds began failing on license scout due to a transitive dependency on the interception gem:

```
Encountered error(s) with project's licensing information.
Failing the build because :fatal_licensing_warnings is set in the configuration.
Error(s):
 
    Dependency 'interception' version '0.5' under 'ruby_bundler' is missing license information.
    >> Found 35 dependencies for ruby_bundler. 34 OK, 1 with problems
    If you are encountering missing license or missing license file errors for **transitive** dependencies, you can provide overrides for the missing information at https://github.com/chef/license_scout/blob/master/lib/license_scout/overrides.rb#L93
```

There was some confusion about how/why this was failing since the verify pipeline was not exhibiting the same symptom.

chef-server's verify pipeline is using the newer license-scout which is able to identify the license properly while the omnibus pipeline uses the older license-scout from the 1-stable branch.

This PR provides the override pointing to the interception LICENSE.MIT file
