### PR TITLE
Add flag that allows you to easily search all subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,21 @@ license_content | A URL to a file where the raw text of the license can be downl
 
 In addition to including any files Licensee identified as potential license files (but couldn't identify), License Scout will also include the Fallback License you specified in the Dependency Manifest.
 
+### Searching Nested Subdirectories
+
+The default behavior of License Scout is to only look for dependency manager files in the root of the `directories` you configure. This is the default behavior to provide the maximum control over which dependencies you want to appear in your report. For example, your project may include an internal only tool for which you do not wish to enforce license acceptance.
+
+However, License Scout also supports deep scanning all of the listed directories for all dependency manager files and generating a full report on all dependencies that the project uses. To do this, either specify the `--include-sub-directories` command line flag, or set `include_subdirectories` to true in your configuration file.
+
+A common use case for this functionality is to run `license_scout` from the root of a project and get a full report for that project.
+
+```
+license_scout --include-sub-directories
+```
+
 ## Habitat Channel Configuration
 
-By default License Scout searches for Habitat package in the `stable`
-channel. If your build process publishes packages to another channel
-by default, you can use the `channel_for_origin` habitat configuration
-option:
+By default License Scout searches for Habitat package in the `stable` channel. If your build process publishes packages to another channel by default, you can use the `channel_for_origin` habitat configuration option:
 
 ```yaml
 habitat:
@@ -216,6 +225,7 @@ Format | Description
 Value | Description | Default
 --- | --- | ---
 directories | The fully-qualified local paths to the directories you wish to scan | _The current working directory._ |
+include_subdirectories | Whether or not to include all nested sub-directories of `directories` in the search. | `false` |
 name | The name you want to give to the scan result. | _The basename of the first directory to be scanned._ |
 output_directory | The path to the directory where the output JSON file should be saved. | _The current working directory._ |
 log_level | What log information should be included in STDOUT | `info` |

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ In addition to including any files Licensee identified as potential license file
 
 ### Searching Nested Subdirectories
 
-The default behavior of License Scout is to only look for dependency manager files in the root of the `directories` you configure. This is the default behavior to provide the maximum control over which dependencies you want to appear in your report. For example, your project may include an internal only tool for which you do not wish to enforce license acceptance.
+License Scout's default behavior is to only look for dependency manager files in the root of the `directories` that you configure. This default behavior provides greater control over the dependencies that you want to appear in your report. For example, you may not want to enforce license acceptance on an internal-only tool that is included in a project.
 
-However, License Scout also supports deep scanning all of the listed directories for all dependency manager files and generating a full report on all dependencies that the project uses. To do this, either specify the `--include-sub-directories` command line flag, or set `include_subdirectories` to true in your configuration file.
+License Scout will also scan subdirectories for all dependency manager files and generate a full report on all dependencies that the project uses. To do this, either specify the `--include-sub-directories` command line flag, or set `include_subdirectories` to true in your configuration file.
 
 A common use case for this functionality is to run `license_scout` from the root of a project and get a full report for that project.
 

--- a/lib/license_scout/cli.rb
+++ b/lib/license_scout/cli.rb
@@ -42,6 +42,11 @@ module LicenseScout
       description: "Comma-separated list of directories to scan",
       proc: Proc.new { |d| d.split(",") }
 
+    option :include_subdirectories,
+      long: "--include-sub-directories",
+      description: "Include all sub-directories of 'directories' in the analysis",
+      boolean: true
+
     option :format,
       long: "--format FORMAT",
       description: "When exporting a Dependency Manifest, export to this format",

--- a/lib/license_scout/collector.rb
+++ b/lib/license_scout/collector.rb
@@ -57,7 +57,7 @@ module LicenseScout
     end
 
     def dependency_managers
-      @dependency_managers ||= LicenseScout::Config.directories.map do |dir|
+      @dependency_managers ||= LicenseScout::Config.all_directories.map do |dir|
         LicenseScout::DependencyManager.implementations.map do |implementation|
           dep_mgr = implementation.new(File.expand_path(dir))
           if dep_mgr.detected?

--- a/lib/license_scout/config.rb
+++ b/lib/license_scout/config.rb
@@ -28,6 +28,7 @@ module LicenseScout
 
     # Inputs
     default :directories, [File.expand_path(Dir.pwd)]
+    default :include_subdirectories, false
     default :name, File.basename(directories.first)
     default :config_files, [File.join(File.expand_path(Dir.pwd), ".license_scout.yml")]
 
@@ -78,6 +79,23 @@ module LicenseScout
     #
 
     class << self
+
+      def all_directories
+        if include_subdirectories
+          new_directories = []
+
+          directories.each do |old_directory|
+            new_directories << old_directory
+            Dir.chdir(old_directory) do
+              new_directories << Dir.glob("**/*").select { |f| File.directory?(f) }.map { |d| File.join(old_directory, d) }
+            end
+          end
+
+          new_directories.flatten.compact
+        else
+          directories
+        end
+      end
 
       def validate!
         if !allowed_licenses.empty? && !flagged_licenses.empty?

--- a/spec/license_scout/config_spec.rb
+++ b/spec/license_scout/config_spec.rb
@@ -75,6 +75,58 @@ RSpec.describe LicenseScout::Config do
     end
   end
 
+  describe ".all_directories" do
+    let(:initial_config) do
+      {
+        directories: [
+          File.join(SPEC_FIXTURES_DIR, "deps_gopath"),
+        ],
+      }
+    end
+
+    let(:expected_directories) do
+      %W{
+        #{SPEC_FIXTURES_DIR}/deps_gopath
+      }
+    end
+
+    it "returns the list of directories" do
+      LicenseScout::Config.merge!(initial_config)
+
+      expect(LicenseScout::Config.all_directories).to match_array(expected_directories)
+    end
+
+    context "with include-sub-directories" do
+      let(:initial_config) do
+        {
+          include_subdirectories: true,
+          directories: [
+            File.join(SPEC_FIXTURES_DIR, "deps_gopath"),
+          ],
+        }
+      end
+
+      let(:expected_directories) do
+        %W{
+          #{SPEC_FIXTURES_DIR}/deps_gopath
+          #{SPEC_FIXTURES_DIR}/deps_gopath/src
+          #{SPEC_FIXTURES_DIR}/deps_gopath/src/gopkg.in
+          #{SPEC_FIXTURES_DIR}/deps_gopath/src/gopkg.in/foo
+          #{SPEC_FIXTURES_DIR}/deps_gopath/src/gopkg.in/foo/baz
+          #{SPEC_FIXTURES_DIR}/deps_gopath/src/github.com
+          #{SPEC_FIXTURES_DIR}/deps_gopath/src/github.com/foo
+          #{SPEC_FIXTURES_DIR}/deps_gopath/src/github.com/foo/bar
+        }
+      end
+
+      it "returns all subdirectories as well" do
+        LicenseScout::Config.merge!(initial_config)
+
+        expect(LicenseScout::Config.all_directories).to match_array(expected_directories)
+      end
+    end
+  end
+
   describe ".validate!" do
     context "when both an allowed and flagged list are specified" do
       before do


### PR DESCRIPTION


<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

There may be situations where it is undesirable or unreasonable to individually specify all the directories you want to scan. This change adds the `--include-all-subdirectories` flag which will tell license scout to also look for dependency manager files in nested subdirectories of the configured directory.

In practice, you could run the following command in the root of a project repository and feel pretty confident that you have identified all of the dependencies of all of the software in that project.

```
license_scout --include-sub-directories
```

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

Addresses #208 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
