### PR TITLE
Add http-accept as a MIT project

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -367,6 +367,7 @@ module LicenseScout
         ["grpc-google-iam-v1", "Apache-2.0", ["https://raw.githubusercontent.com/googleapis/googleapis/master/LICENSE"]],
         ["grpc", "Apache-2.0", ["https://raw.githubusercontent.com/grpc/grpc/master/LICENSE"]],
         ["hoe", "MIT", ["https://raw.githubusercontent.com/seattlerb/hoe/master/README.rdoc"]],
+        ["http-accept", "MIT", ["https://raw.githubusercontent.com/socketry/http-accept/master/README.md"]],
         ["http_parser.rb", nil, ["https://raw.githubusercontent.com/tmm1/http_parser.rb/master/LICENSE-MIT"]],
         ["inspec-msccm", nil, [canonical("Chef-MLSA")]],
         ["inspec-scap", nil, [canonical("Chef-MLSA")]],


### PR DESCRIPTION
chef-server is failing omnibus builds due to license scout being unable to resolve `http-accept`:

https://buildkite.com/chef/chef-chef-server-master-omnibus-adhoc/builds/468

This PR points license scout at `http-accept`'s `README.md` file where the license is identifed as MIT.
