### PR TITLE
Allow mixlib-shellout 3.x

### DIFF
--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -36,10 +36,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w{lib}
 
   spec.add_dependency "ffi-yajl",         "~> 2.2"
-  spec.add_dependency "mixlib-shellout",  "~> 2.2"
+  spec.add_dependency "mixlib-shellout",  ">= 2.2", "< 4.0"
   spec.add_dependency "toml-rb",  "~> 1.0"
 
-  spec.add_development_dependency "rake", ">= 10.0", "< 13"
+  spec.add_development_dependency "rake", ">= 10.0", "< 14"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rb-readline"


### PR DESCRIPTION
In omnibus installs we're unable to bring in the new chef release since
that needs mixlib-shellout 3.x.

Signed-off-by: Tim Smith <tsmith@chef.io>