### PR TITLE
Add license information for erlcloud

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -549,6 +549,8 @@ module LicenseScout
         ["ibrowse", "BSD-2-Clause", nil],
         ["eunit_formatters", "Apache-2.0", ["https://raw.githubusercontent.com/seancribbs/eunit_formatters/master/README.md"]],
         ["erlware_commons", "MIT", ["https://raw.githubusercontent.com/erlware/erlware_commons/master/COPYING"]],
+        ["erlcloud", "BSD-2-Clause", ["https://raw.githubusercontent.com/erlcloud/erlcloud/master/COPYRIGHT"]],
+        ["lhttpc", "BSD-2-Clause", ["https://raw.githubusercontent.com/erlcloud/lhttpc/master/LICENCE"]],
         ["getopt", "MIT", nil],
         ["relx", "Apache-2.0", ["https://raw.githubusercontent.com/erlware/relx/master/LICENSE.md"]],
       ].each do |override_data|


### PR DESCRIPTION
Signed-off-by: Prajakta Purohit <prajakta@chef.io>

Add license information for license_scout.

- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
