### PR TITLE
update ruby version to 2.6

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -18,7 +18,7 @@ pkg_build_deps=(
 pkg_deps=(
   core/openssl
   core/zlib
-  core/ruby25
+  core/ruby26
   core/git
   core/curl
   core/coreutils
@@ -34,12 +34,12 @@ do_unpack() {
 do_prepare() {
   build_line "Scoping default paths to Habitat installation"
   sed -i -r "s|^(\s*)default :escript_bin, \".+\"|\1default :escript_bin, \"$(hab pkg path core/erlang18)/bin/escript\"|" "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib/license_scout/config.rb"
-  sed -i -r "s|^(\s*)default :ruby_bin, \".+\"|\1default :ruby_bin, \"$(hab pkg path core/ruby25)/bin/ruby\"|" "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib/license_scout/config.rb"
+  sed -i -r "s|^(\s*)default :ruby_bin, \".+\"|\1default :ruby_bin, \"$(hab pkg path core/ruby26)/bin/ruby\"|" "$HAB_CACHE_SRC_PATH/$pkg_dirname/lib/license_scout/config.rb"
 
-  local _ruby_gems=$(pkg_path_for "core/ruby25")/lib/ruby/gems/2.5.0
+  local _ruby_gems=$(pkg_path_for "core/ruby26")/lib/ruby/gems/2.6.0
   local _pkg_gems="$pkg_prefix/lib"
 
-  export GEM_HOME="${_pkg_gems}/ruby/2.5.0"
+  export GEM_HOME="${_pkg_gems}/ruby/2.6.0"
   build_line "Setting GEM_HOME=$GEM_HOME"
 
   export GEM_PATH="${_ruby_gems}:${GEM_HOME}"
@@ -85,7 +85,7 @@ do_install() {
   build_line "Ensure license_scout binaries are executable from anywhere"
   wrap_license_scout_bin
 
-  fix_interpreter "$pkg_prefix/bin/gemfile_json" core/ruby25 ruby
+  fix_interpreter "$pkg_prefix/bin/gemfile_json" core/ruby26 ruby
 }
 
 wrap_license_scout_bin() {
@@ -102,7 +102,7 @@ export GEM_HOME="$GEM_HOME"
 export GEM_PATH="$GEM_PATH"
 unset RUBYOPT GEMRC
 
-exec $(pkg_path_for core/ruby25)/bin/ruby $real_bin \$@
+exec $(pkg_path_for core/ruby26)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$wrap_bin"
 }


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

 Fix build failure 
## Description
 Build https://buildkite.com/chef/chef-license-scout-master-habitat-build/builds/9  was failing with following error
   
ERROR:  Error installing berkshelf:
--
  | The last version of chef-zero (>= 14.0.11) to support your Ruby & RubyGems was 14.0.17. Try installing it with `gem install chef-zero -v 14.0.17` and then running the current command again
  | chef-zero requires Ruby version >= 2.6. The current ruby version is 2.5.0.
  | license_scout: Build time: 2m31s
  | license_scout: Exiting on error
  | 🚨 Error: The command exited with status 1

Current ruby version is 2.5 ,updated it to 2.6 and build is passing successfully

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
