### PR TITLE
Add simplecov json formatter

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -333,6 +333,7 @@ module LicenseScout
         ["rework", "MIT", ["Readme.md"]],
         ["rspec", "MIT", nil],
         ["sequel", "MIT", nil],
+        ["simplecov_json_formatter", "MIT", nil],
         ["source-map-resolve", "MIT", ["LICENSE"]],
         ["source-map-url", "MIT", ["LICENSE"]],
         ["spork", "MIT", nil],


### PR DESCRIPTION
```Error(s):  Dependency 'simplecov_json_formatter' version '0.1.2' under 'ruby_bundler' is missing license files information. >> Found 38 dependencies for ruby_bundler. 37 OK, 1 with problems If you are encountering missing license or missing license file errors for **transitive** dependencies, you can provide overrides for the missing information at https://github.com/chef/license_scout/blob/1-stable/lib/license_scout/overrides.rb#L93.  Promote license_scout to Rubygems with `/expeditor promote chef/license_scout:1-stable X.Y.Z` in slack.` ```