### PR TITLE
Fix warning: Kernel#open is deprecated

### DIFF
--- a/lib/license_scout/license.rb
+++ b/lib/license_scout/license.rb
@@ -106,7 +106,7 @@ module LicenseScout
 
         begin
           LicenseScout::Log.debug("[license] Pulling license content for #{license_id} from #{new_url}")
-          open(new_url).read
+          URI.open(new_url).read
         rescue RuntimeError => e
           if e.message =~ /redirection forbidden/
             m = /redirection forbidden:\s+(.+)\s+->\s+(.+)/.match(e.message)

--- a/spec/license_scout/license_spec.rb
+++ b/spec/license_scout/license_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe LicenseScout::License do
   let(:apache_license_content) { File.read(File.join(SPEC_FIXTURES_DIR, "empty_project", "LICENSE")) }
   let(:record) { described_class::Record.new(spdx, source, apache_license_content) }
 
-  before do
-    allow(described_class::Record).to receive(:new).with(spdx, source, apache_license_content).and_return(record)
-  end
-
   describe ".new" do
     let(:subject) { described_class.new(dependency_path) }
+
+    before do
+      allow(described_class::Record).to receive(:new).with(spdx, source, apache_license_content).and_return(record)
+    end
 
     context "when path is nil" do
       let(:dependency_path) { nil }
@@ -89,6 +89,25 @@ RSpec.describe LicenseScout::License do
       let(:flagged_licenses) { ["MIT"] }
 
       it { is_expected.to be false }
+    end
+  end
+
+  describe "#add_license" do
+    let(:license_url) { "https://url/to/license" }
+    let(:options) { { a: 42 } }
+
+    subject { described_class.new(dependency_path) }
+
+    it "downloads license body and adds a new record" do
+      expect(URI).to receive(:open).with(license_url).and_return(StringIO.new(apache_license_content))
+
+      subject.add_license(spdx, source, license_url, options)
+
+      new_record = subject.records.last
+      expect(new_record).not_to be_nil
+      expect(new_record.id).to eq(spdx)
+      expect(new_record.source).to eq(source)
+      expect(new_record.content).to eq(apache_license_content)
     end
   end
 end


### PR DESCRIPTION
## Description

Opening URIs by redirecting through `Kernel#open` is deprecated as of Ruby 2.7 and is dropped in Ruby 3.0.

To unblock applications that use Ruby 3, we need to replace these calls with `URI.open`.

See also:

* https://rubyreferences.github.io/rubychanges/2.7.html#network-and-web
* https://github.com/ruby/open-uri/commit/53862fa35887a34a8060aebf2241874240c2986a

## Related Issue

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [-] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
