### PR TITLE
Change mixlib-shellout dependency pattern to allow 3.x

### DIFF
--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w{lib}
 
   spec.add_runtime_dependency "ffi-yajl",        "~> 2.2"
-  spec.add_runtime_dependency "mixlib-shellout", "~> 2.2"
+  spec.add_runtime_dependency "mixlib-shellout", ">= 2.2", "< 4.0"
   spec.add_runtime_dependency "toml-rb",         "~> 1.0"
   spec.add_runtime_dependency "licensee",        "~> 9.8"
   spec.add_runtime_dependency "mixlib-config",   "~> 2.2"


### PR DESCRIPTION
## Description

There is an incompatibility with chef >= 15.x, omnibus >=7.0 and license_scout >= 2.x where they run into dependency incompatibilities due to chef requiring mixlib-shellout 3.x while license_scout has it pinned to 2.2.

At GitLab we use omnibus 7.0.10 and chef 15.14. When updating license_scout to 2.2, we run into the following bundler errors:

```
Bundler could not find compatible versions for gem "mixlib-shellout":
  In snapshot (Gemfile.lock):
    mixlib-shellout (= 3.0.9)

  In Gemfile:
    chef (~> 15.14.0) was resolved to 15.14.0, which depends on
      mixlib-shellout (>= 3.0.3, < 4.0)

    omnibus was resolved to 7.0.10, which depends on
      license_scout (~> 2.0) was resolved to 2.6.2, which depends on
        mixlib-shellout (~> 2.2)

    ohai (~> 15.12.0) was resolved to 15.12.0, which depends on
      mixlib-shellout (>= 2.0, < 4.0)
```

It looks like the pin on 2.2 was introduced in 2016 with this commit: https://github.com/chef/license_scout/commit/3d9d2fc2af8edca4ea2b8463aaf2c89421bc6dec

## Related Issue

Required for us to benefit from https://github.com/chef/license_scout/pull/264 which is released as v2.6.2.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
