### PR TITLE
Fix override for ExtUtils-ParseXS

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -494,7 +494,7 @@ module LicenseScout
         ["ExtUtils-Install", nil, ["README"]],
         ["File-Path", nil, ["README"]],
         ["Getopt-Long", "Perl-5", ["README"]],
-        ["ExtUtils-ParseXS", "Perl-5", ["README"]],
+        ["ExtUtils-ParseXS", "Perl-5", ["META.json"]],
         ["version", nil, ["README"]],
         ["Data-Dumper", "Perl-5", ["Dumper.pm"]],
         ["Test-Harness", nil, ["README"]],


### PR DESCRIPTION
Fix override for ExtUtils-ParseXS

ExtUtils-ParseXS 3.44 was just released and it does not have a README file. It does have a META.json.