### PR TITLE
Add transitive dependency overrides for rebar3 upgrade

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -571,6 +571,12 @@ module LicenseScout
 
       # erlang_rebar
       [
+        ["base16", "BSD-2-Clause", ["LICENSE"]],
+        ["eini", "Apache-2.0", ["LICENSE"]],
+        ["fs", "ISC", ["LICENSE"]],
+        ["goldrush", "ISC", ["LICENSE"]],
+        ["jsx", "MIT", ["LICENSE"]],
+        ["recon", "BSD-3-Clause", ["LICENSE"]],
         ["sync", "MIT", ["https://raw.githubusercontent.com/rustyio/sync/11df81d196eaab2d84caa3fbe8def5d476ef79d8/src/sync.erl"]],
         ["rebar_vsn_plugin", "Apache-2.0", ["https://raw.githubusercontent.com/erlware/rebar_vsn_plugin/master/src/rebar_vsn_plugin.erl"]],
         ["edown", "Erlang-Public", ["https://raw.githubusercontent.com/seth/edown/master/NOTICE"]],


### PR DESCRIPTION
Fix license scout errors.

Upgrading rebar3 causes license_scout to fail to find some preexisting transitive dependencies.  Nothing new has been added (no code, no dependencies), we are simply upgrading rebar3, which causes some license_scout errors.

Dependency tree snippet for the failing dependencies:

```
└─ oc_erchef─15.3.11-bc91cb4df (project app)
   ├─ erlcloud─3.2.16+build.1978.ref52ff8e7 (git repo)
   │  ├─ base16─1.0.0 (hex package)
   │  ├─ eini─1.2.6 (hex package)
   │  ├─ jsx─2.9.0 (hex package)

└─ oc_erchef─15.3.11-bc91cb4df (project app)
   ├─ sync─0.2.0 (git repo)
   │  └─ fs─6.1.1 (hex package)

└─ oc_erchef─15.3.11-bc91cb4df (project app)
   ├─ lager─3.9.2 (git repo)
   │  └─ goldrush─0.1.9 (hex package)

└─ oc_erchef─15.3.11-bc91cb4df (project app)
   ├─ observer_cli─1.6.1 (git repo)
   │  └─ recon─2.5.1 (hex package)
```