### PR TITLE
chef server adhoc build fix - license of nio4r changed to readme.md

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -398,7 +398,7 @@ module LicenseScout
         ["multipart-post", "MIT", ["https://raw.githubusercontent.com/socketry/multipart-post/main/license.md"]],
         ["net-http-spy", "Public-Domain", ["https://raw.githubusercontent.com/martinbtt/net-http-spy/master/readme.markdown"]],
         ["net-protocol", "BSD-2-Clause", ["https://raw.githubusercontent.com/ruby/net-protocol/master/LICENSE.txt"]],
-        ["nio4r", "MIT", ["https://raw.githubusercontent.com/socketry/nio4r/master/README.md"]],
+        ["nio4r", "MIT", ["https://raw.githubusercontent.com/socketry/nio4r/master/readme.md"]],
         ["omniauth-chef", nil, ["https://raw.githubusercontent.com/chef/omniauth-chef/master/README.md"]],
         ["options", "Ruby", ["https://rubygems.org/gems/options"]],
         ["os", "MIT", ["https://raw.githubusercontent.com/rdp/os/master/LICENSE"]],


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
chef server adhoc build fix - license of nio4r changed to readme.md
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5617#018875c5-2077-4df6-aa4d-4c2d55e56fa0
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://buildkite.com/chef/chef-chef-server-main-omnibus-adhoc/builds/5617#018875c5-2077-4df6-aa4d-4c2d55e56fa0
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
