### PR TITLE
Chef 13052 chef builds failing on license errorss

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -431,7 +431,7 @@ module LicenseScout
         ["therubyracer", "MIT", ["https://raw.githubusercontent.com/rubyjs/therubyracer/master/README.md"]],
         ["thin", "BSD-2-Clause", ["https://raw.githubusercontent.com/macournoyer/thin/master/README.md"]],
         ["time", "BSD-2-Clause", ["https://raw.githubusercontent.com/ruby/time/master/LICENSE.txt"]],
-        ["timeout", "BSD-2-Clause", ["https://raw.githubusercontent.com/ruby/timeout/master/LICENSE.txt"]],
+        ["timeout", "BSD-2-Clause", ["https://raw.githubusercontent.com/ruby/timeout/master/BSDL"]],
         ["unicorn-rails", "MIT", ["https://raw.githubusercontent.com/samuelkadolph/unicorn-rails/master/LICENSE"]],
         ["uri_template", "MIT", ["https://raw.githubusercontent.com/hannesg/uri_template/master/uri_template.gemspec"]],
         ["url", "MIT", ["https://raw.githubusercontent.com/tal/URL/master/LICENSE"]],

--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -37,9 +37,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency "ffi-yajl",         "~> 2.2"
-  spec.add_dependency "mixlib-shellout",  ">= 2.2", "< 4.0"
-  spec.add_dependency "toml-rb",  ">= 1", "< 3"
+  spec.add_dependency "ffi-yajl", "~> 2.2"
+  spec.add_dependency "mixlib-shellout", ">= 2.2", "< 4.0"
+  spec.add_dependency "toml-rb", ">= 1", "< 3"
+  spec.add_dependency "nori", "< 2.7.0"
 
   spec.add_development_dependency "rake", ">= 10.0", "< 14"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
infra-client builds are failing due to license errors https://buildkite.com/chef/chef-chef-main-validate-adhoc/builds/1534#018fdcbf-2a09-4f71-9d1d-2336dcbe7651/223-1355  this is because of Recently there was a change happened on ruby/timeout repo where they modified the url LICENSE.txt to BSDL  , here is the reference https://github.com/ruby/timeout/commit/6c99460887e820c54ee7c19350b93bdc58785fca

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
