### PR TITLE
Drop support for ruby 2.7 from verify pipeline/muthuja

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -9,16 +9,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.7
-  command:
-    - .expeditor/buildkite/verify.sh
-  expeditor:
-    cached_folders:
-      - vendor
-    executor:
-      docker:
-        image: ruby:2.7-buster
-
 - label: run-lint-and-specs-ruby-3.0
   command:
     - .expeditor/buildkite/verify.sh

--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -40,7 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ffi-yajl", "~> 2.2"
   spec.add_dependency "mixlib-shellout", ">= 2.2", "< 4.0"
   spec.add_dependency "toml-rb", ">= 1", "< 3"
-  spec.add_dependency "nori", "< 2.7.0"
 
   spec.add_development_dependency "rake", ">= 10.0", "< 14"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This change will remove support for ruby 2.7 tests from verify pipeline since it was old and no longer supported

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
