### PR TITLE
include license file for stringio

### DIFF
--- a/lib/license_scout/overrides.rb
+++ b/lib/license_scout/overrides.rb
@@ -434,6 +434,7 @@ module LicenseScout
         ["thin", "BSD-2-Clause", ["https://raw.githubusercontent.com/macournoyer/thin/master/README.md"]],
         ["time", "BSD-2-Clause", ["https://raw.githubusercontent.com/ruby/time/master/BSDL"]],
         ["timeout", "BSD-2-Clause", ["https://raw.githubusercontent.com/ruby/timeout/master/BSDL"]],
+        ["stringio", "BSD-2-Clause", ["https://raw.githubusercontent.com/ruby/stringio/master/LICENSE.txt"]],
         ["unicorn-rails", "MIT", ["https://raw.githubusercontent.com/samuelkadolph/unicorn-rails/master/LICENSE"]],
         ["uri_template", "MIT", ["https://raw.githubusercontent.com/hannesg/uri_template/master/uri_template.gemspec"]],
         ["url", "MIT", ["https://raw.githubusercontent.com/tal/URL/master/LICENSE"]],


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
We recently added stringio gem in chef-18 gemfile.lock file which requires licensing information .

<img width="1382" alt="Screenshot 2024-10-28 at 10 38 53 PM" src="https://github.com/user-attachments/assets/7ee456c3-c36f-4731-ba02-4788ca2c01c0">


## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
