### PR TITLE
CHEF-27669 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -260,3 +260,6 @@ OCTOKIT_ACCESS_TOKEN=your_token_value
 
 - [Dan DeLeo](https://github.com/danielsdeleo)
 - [Tom Duffield](https://github.com/tduffield)
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/gemfile_json
+++ b/bin/gemfile_json
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/bin/license_scout
+++ b/bin/license_scout
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout.rb
+++ b/lib/license_scout.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/cli.rb
+++ b/lib/license_scout/cli.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/collector.rb
+++ b/lib/license_scout/collector.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/config.rb
+++ b/lib/license_scout/config.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency.rb
+++ b/lib/license_scout/dependency.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager.rb
+++ b/lib/license_scout/dependency_manager.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/base.rb
+++ b/lib/license_scout/dependency_manager/base.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/berkshelf.rb
+++ b/lib/license_scout/dependency_manager/berkshelf.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/bundler.rb
+++ b/lib/license_scout/dependency_manager/bundler.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/cargo.rb
+++ b/lib/license_scout/dependency_manager/cargo.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/cpanm.rb
+++ b/lib/license_scout/dependency_manager/cpanm.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/dep.rb
+++ b/lib/license_scout/dependency_manager/dep.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/glide.rb
+++ b/lib/license_scout/dependency_manager/glide.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2017, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/godep.rb
+++ b/lib/license_scout/dependency_manager/godep.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/gomod.rb
+++ b/lib/license_scout/dependency_manager/gomod.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2020, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/habitat.rb
+++ b/lib/license_scout/dependency_manager/habitat.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/mix.rb
+++ b/lib/license_scout/dependency_manager/mix.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/npm.rb
+++ b/lib/license_scout/dependency_manager/npm.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/dependency_manager/rebar.rb
+++ b/lib/license_scout/dependency_manager/rebar.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/exceptions.rb
+++ b/lib/license_scout/exceptions.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/exporter.rb
+++ b/lib/license_scout/exporter.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/exporter/csv.rb
+++ b/lib/license_scout/exporter/csv.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/license.rb
+++ b/lib/license_scout/license.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/log.rb
+++ b/lib/license_scout/log.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/reporter.rb
+++ b/lib/license_scout/reporter.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/spdx.rb
+++ b/lib/license_scout/spdx.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/license_scout/version.rb
+++ b/lib/license_scout/version.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/license_scout.gemspec
+++ b/license_scout.gemspec
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2016, Chef Software Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/collector_spec.rb
+++ b/spec/license_scout/collector_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/config_spec.rb
+++ b/spec/license_scout/config_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/base_spec.rb
+++ b/spec/license_scout/dependency_manager/base_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/berkshelf_spec.rb
+++ b/spec/license_scout/dependency_manager/berkshelf_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/bundler_spec.rb
+++ b/spec/license_scout/dependency_manager/bundler_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/cargo_spec.rb
+++ b/spec/license_scout/dependency_manager/cargo_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/cpanm_spec.rb
+++ b/spec/license_scout/dependency_manager/cpanm_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/dep_spec.rb
+++ b/spec/license_scout/dependency_manager/dep_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/glide_spec.rb
+++ b/spec/license_scout/dependency_manager/glide_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/godep_spec.rb
+++ b/spec/license_scout/dependency_manager/godep_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/gomod_spec.rb
+++ b/spec/license_scout/dependency_manager/gomod_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/habitat_spec.rb
+++ b/spec/license_scout/dependency_manager/habitat_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/mix_spec.rb
+++ b/spec/license_scout/dependency_manager/mix_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/npm_spec.rb
+++ b/spec/license_scout/dependency_manager/npm_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager/rebar_spec.rb
+++ b/spec/license_scout/dependency_manager/rebar_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_manager_spec.rb
+++ b/spec/license_scout/dependency_manager_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/dependency_spec.rb
+++ b/spec/license_scout/dependency_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/exporter_spec.rb
+++ b/spec/license_scout/exporter_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/license_spec.rb
+++ b/spec/license_scout/license_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/spec/license_scout/spdx_spec.rb
+++ b/spec/license_scout/spdx_spec.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2016-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2016-2025 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `bin/license_scout:3` - Copyright in LICENSE file (move to COPYRIGHT)
- `lib/license_scout.rb:2` - Copyright in LICENSE file (move to COPYRIGHT)
- `lib/license_scout/license.rb:2` - Copyright in LICENSE file (move to COPYRIGHT)
- `license_scout.gemspec:2` - Copyright in LICENSE file (move to COPYRIGHT)
- `spec/license_scout/license_spec.rb:2` - Copyright in LICENSE file (move to COPYRIGHT)

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
